### PR TITLE
fix(build): macOS compatibility in build.sh (bash 3.2, zsh)

### DIFF
--- a/quantecon/build.sh
+++ b/quantecon/build.sh
@@ -28,7 +28,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 FEATURES_FILE="$SCRIPT_DIR/features.txt"
 INTEGRATION_BRANCH="quantecon"
 BASE_BRANCH="main"
@@ -58,7 +58,11 @@ if [[ -n "$(git status --porcelain)" ]]; then
 fi
 
 # Read feature branches (strip comments and blank lines, extract first token)
-mapfile -t FEATURES < <(awk '/^[[:space:]]*#/{next} /^[[:space:]]*$/{next} {print $1}' "$FEATURES_FILE")
+# (mapfile/readarray is bash 4+ only; this while-read loop works on bash 3.2 and zsh)
+FEATURES=()
+while IFS= read -r _branch; do
+  FEATURES+=("$_branch")
+done < <(awk '/^[[:space:]]*#/{next} /^[[:space:]]*$/{next} {print $1}' "$FEATURES_FILE")
 
 if [[ ${#FEATURES[@]} -eq 0 ]]; then
   echo "No feature branches listed in $FEATURES_FILE. Nothing to do."


### PR DESCRIPTION
## Summary

macOS ships bash 3.2 (GPLv2 restriction); `build.sh` used two bash 4+ features that fail on macOS without Homebrew bash installed.

### Changes

- **chmod +x** — store script as executable in git (mode `100755`)
- **`BASH_SOURCE[0]:-$0`** — guard against zsh where `BASH_SOURCE` is unset, causing `parameter not set` error under `set -u`
- **`while IFS= read -r` loop** — replaces `mapfile -t` which is bash 4+ only (`mapfile: command not found` on macOS system bash 3.2)

Tested locally on macOS (arm64, bash 3.2.57) — build succeeds and produces the `quantecon` integration branch correctly.