### PR TITLE
Book parts: section: parts dividers with Roman labels

### DIFF
--- a/.changeset/book-parts.md
+++ b/.changeset/book-parts.md
@@ -1,0 +1,6 @@
+---
+"myst-toc": patch
+"myst-cli": patch
+---
+
+Book-style parts: `section: parts` ParentEntry emits a Roman-numbered divider folder ("Part I — Theory") and wraps chapter groups. Chapter counter continues across part boundaries; children default to `section: chapters`. Project-level overrides via `numbering.parts.{format,label}`.

--- a/packages/myst-cli/src/project/fromTOC.parts.spec.ts
+++ b/packages/myst-cli/src/project/fromTOC.parts.spec.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import memfs from 'memfs';
+import { resolve } from 'node:path';
+import { Session } from '../session';
+import { projectFromTOC } from './fromTOC';
+import { config } from '../store/index.js';
+import type { LocalProjectFolder, LocalProjectPage } from './types.js';
+
+vi.mock('fs', () => ({ ['default']: memfs.fs }));
+
+beforeEach(() => memfs.vol.reset());
+
+const session = new Session();
+
+/**
+ * Prime the project config in the store. `projectFromTOC` reads
+ * `numbering.parts.{format,label}` and `numbering.book.enabled` via
+ * `selectors.selectLocalProjectConfig`.
+ */
+function primeProjectConfig(path: string, projectConfig: Record<string, unknown>) {
+  session.store.dispatch(
+    config.actions.receiveProjectConfig({ path: resolve(path), ...projectConfig } as any),
+  );
+}
+
+/**
+ * Helpers — strip absolute paths from page outputs so assertions stay
+ * portable (memfs gives us absolute paths via `path.resolve`).
+ */
+function basename(p: string): string {
+  return p.split('/').pop() ?? p;
+}
+function simplifyPages(pages: (LocalProjectFolder | LocalProjectPage)[]) {
+  return pages.map((p) => {
+    if ('file' in p) {
+      return { ...p, file: basename(p.file) };
+    }
+    return p;
+  });
+}
+
+describe('projectFromTOC: section parts', () => {
+  it('emits a part divider folder with Roman label when book mode is on', () => {
+    memfs.vol.fromJSON({ 'index.md': '', 'ch1.md': '', 'ch2.md': '' });
+    primeProjectConfig('.', { numbering: { book: { enabled: true } } });
+    const proj = projectFromTOC(session, '.', [
+      { file: 'index' },
+      {
+        title: 'Theory',
+        section: 'parts',
+        children: [{ file: 'ch1' }, { file: 'ch2' }],
+      },
+    ]);
+    expect(simplifyPages(proj.pages)).toEqual([
+      { level: -1, section: 'parts', title: 'Part I — Theory' },
+      { file: 'ch1.md', slug: 'ch1', level: 0, section: 'chapters' },
+      { file: 'ch2.md', slug: 'ch2', level: 0, section: 'chapters' },
+    ]);
+  });
+
+  it('chapter counter continues across part boundaries', () => {
+    memfs.vol.fromJSON({
+      'index.md': '',
+      'ch1.md': '',
+      'ch2.md': '',
+      'ch3.md': '',
+      'ch4.md': '',
+    });
+    primeProjectConfig('.', { numbering: { book: { enabled: true } } });
+    const proj = projectFromTOC(session, '.', [
+      { file: 'index' },
+      {
+        title: 'Theory',
+        section: 'parts',
+        children: [{ file: 'ch1' }, { file: 'ch2' }],
+      },
+      {
+        title: 'Applications',
+        section: 'parts',
+        children: [{ file: 'ch3' }, { file: 'ch4' }],
+      },
+    ]);
+    // Roman part counter increments I → II; chapter section unchanged.
+    // (heading_1 counter continuity is verified end-to-end in the demo.)
+    expect(simplifyPages(proj.pages)).toEqual([
+      { level: -1, section: 'parts', title: 'Part I — Theory' },
+      { file: 'ch1.md', slug: 'ch1', level: 0, section: 'chapters' },
+      { file: 'ch2.md', slug: 'ch2', level: 0, section: 'chapters' },
+      { level: -1, section: 'parts', title: 'Part II — Applications' },
+      { file: 'ch3.md', slug: 'ch3', level: 0, section: 'chapters' },
+      { file: 'ch4.md', slug: 'ch4', level: 0, section: 'chapters' },
+    ]);
+  });
+
+  it('parts coexist with appendices (logical section group)', () => {
+    memfs.vol.fromJSON({ 'index.md': '', 'ch1.md': '', 'app-a.md': '' });
+    primeProjectConfig('.', { numbering: { book: { enabled: true } } });
+    const proj = projectFromTOC(session, '.', [
+      { file: 'index' },
+      {
+        title: 'Theory',
+        section: 'parts',
+        children: [{ file: 'ch1' }],
+      },
+      {
+        title: 'Appendices',
+        section: 'appendices',
+        children: [{ file: 'app-a' }],
+      },
+    ]);
+    expect(simplifyPages(proj.pages)).toEqual([
+      { level: -1, section: 'parts', title: 'Part I — Theory' },
+      { file: 'ch1.md', slug: 'ch1', level: 0, section: 'chapters' },
+      // Appendices is *logical*: no folder, same level as chapters.
+      { file: 'app-a.md', slug: 'app-a', level: 0, section: 'appendices' },
+    ]);
+  });
+
+  it('numbering.parts.format overrides Roman default', () => {
+    memfs.vol.fromJSON({ 'index.md': '', 'ch1.md': '' });
+    primeProjectConfig('.', {
+      numbering: { book: { enabled: true }, parts: { format: 'arabic' } },
+    });
+    const proj = projectFromTOC(session, '.', [
+      { file: 'index' },
+      {
+        title: 'Theory',
+        section: 'parts',
+        children: [{ file: 'ch1' }],
+      },
+    ]);
+    expect(simplifyPages(proj.pages)[0]).toEqual({
+      level: -1,
+      section: 'parts',
+      title: 'Part 1 — Theory',
+    });
+  });
+
+  it('numbering.parts.label overrides "Part %s" default', () => {
+    memfs.vol.fromJSON({ 'index.md': '', 'ch1.md': '' });
+    primeProjectConfig('.', {
+      numbering: { book: { enabled: true }, parts: { label: 'Book %s' } },
+    });
+    const proj = projectFromTOC(session, '.', [
+      { file: 'index' },
+      {
+        title: 'Theory',
+        section: 'parts',
+        children: [{ file: 'ch1' }],
+      },
+    ]);
+    expect(simplifyPages(proj.pages)[0]).toEqual({
+      level: -1,
+      section: 'parts',
+      title: 'Book I — Theory',
+    });
+  });
+
+  it('skips part formatting when book mode is off', () => {
+    memfs.vol.fromJSON({ 'index.md': '', 'ch1.md': '' });
+    // No book.enabled — formatting should not fire; raw title used.
+    primeProjectConfig('.', {});
+    const proj = projectFromTOC(session, '.', [
+      { file: 'index' },
+      {
+        title: 'Theory',
+        section: 'parts',
+        children: [{ file: 'ch1' }],
+      },
+    ]);
+    expect(simplifyPages(proj.pages)[0]).toEqual({
+      level: -1,
+      section: 'parts',
+      title: 'Theory',
+    });
+  });
+
+  it('children of section: parts default to section: chapters', () => {
+    memfs.vol.fromJSON({ 'index.md': '', 'ch1.md': '' });
+    primeProjectConfig('.', { numbering: { book: { enabled: true } } });
+    const proj = projectFromTOC(session, '.', [
+      { file: 'index' },
+      {
+        title: 'Theory',
+        section: 'parts',
+        children: [{ file: 'ch1' }],
+      },
+    ]);
+    const chPage = simplifyPages(proj.pages).find(
+      (p): p is { file: string; section: string; slug: string; level: number } =>
+        'file' in p && p.file === 'ch1.md',
+    );
+    expect(chPage?.section).toBe('chapters');
+  });
+
+  it('no parts in TOC → top-level level stays at 1 (regression)', () => {
+    // Existing TOCs without parts must not have their page levels shifted
+    // by the parts auto-detection.
+    memfs.vol.fromJSON({ 'index.md': '', 'ch1.md': '' });
+    primeProjectConfig('.', { numbering: { book: { enabled: true } } });
+    const proj = projectFromTOC(session, '.', [
+      { file: 'index' },
+      {
+        title: 'Chapters',
+        section: 'chapters',
+        children: [{ file: 'ch1' }],
+      },
+    ]);
+    const chPage = simplifyPages(proj.pages).find(
+      (p): p is { file: string; section: string; slug: string; level: number } =>
+        'file' in p && p.file === 'ch1.md',
+    );
+    expect(chPage?.level).toBe(1);
+  });
+});

--- a/packages/myst-cli/src/project/fromTOC.parts.spec.ts
+++ b/packages/myst-cli/src/project/fromTOC.parts.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import memfs from 'memfs';
-import { resolve } from 'node:path';
+import { basename, resolve } from 'node:path';
 import { Session } from '../session';
 import { projectFromTOC } from './fromTOC';
 import { config } from '../store/index.js';
@@ -25,11 +25,10 @@ function primeProjectConfig(path: string, projectConfig: Record<string, unknown>
 
 /**
  * Helpers — strip absolute paths from page outputs so assertions stay
- * portable (memfs gives us absolute paths via `path.resolve`).
+ * portable (memfs gives us absolute paths via `path.resolve`). Use
+ * `path.basename` so the split handles platform-native separators
+ * (forward slash on POSIX, backslash on Windows).
  */
-function basename(p: string): string {
-  return p.split('/').pop() ?? p;
-}
 function simplifyPages(pages: (LocalProjectFolder | LocalProjectPage)[]) {
   return pages.map((p) => {
     if ('file' in p) {
@@ -191,6 +190,31 @@ describe('projectFromTOC: section parts', () => {
         'file' in p && p.file === 'ch1.md',
     );
     expect(chPage?.section).toBe('chapters');
+  });
+
+  it('FileEntry with section: parts does NOT trigger the parts level shift', () => {
+    // Regression for Copilot review #2 on PR #26: hasPartsSubtree must
+    // match the emission predicate exactly. A FileEntry tagged with
+    // section: parts is malformed (a divider can't be a file), so it
+    // gets downgraded to section: chapters without emitting a folder —
+    // and crucially must not shift the top-level level to -1.
+    memfs.vol.fromJSON({ 'index.md': '', 'rogue.md': '' });
+    primeProjectConfig('.', { numbering: { book: { enabled: true } } });
+    const proj = projectFromTOC(session, '.', [
+      { file: 'index' },
+      // FileEntry with section: parts — should be treated as a regular
+      // page (no part folder, no level shift). The section downgrades
+      // to 'chapters' via the parts→chapters child-default rule.
+      { file: 'rogue', section: 'parts' } as any,
+    ]);
+    const page = simplifyPages(proj.pages).find(
+      (p): p is { file: string; section: string; slug: string; level: number } =>
+        'file' in p && p.file === 'rogue.md',
+    );
+    expect(page?.level).toBe(1); // not -1
+    expect(page?.section).toBe('chapters');
+    // No part divider folder emitted.
+    expect(proj.pages.some((p) => !('file' in p) && p.section === 'parts')).toBe(false);
   });
 
   it('no parts in TOC → top-level level stays at 1 (regression)', () => {

--- a/packages/myst-cli/src/project/fromTOC.parts.spec.ts
+++ b/packages/myst-cli/src/project/fromTOC.parts.spec.ts
@@ -217,6 +217,37 @@ describe('projectFromTOC: section parts', () => {
     expect(proj.pages.some((p) => !('file' in p) && p.section === 'parts')).toBe(false);
   });
 
+  it('parts compose with numbering.proof.scope: section (#28 interaction)', () => {
+    // Smoke test: setting `numbering.proof.scope: section` (the LaTeX-style
+    // section-scoped numbering shipped in #28) must not perturb the parts
+    // TOC parser. The two features operate at different layers — parts
+    // are a TOC artefact; scope is an in-page counter — but a future
+    // change that accidentally couples them (e.g. by reading scope inside
+    // fromTOC) would silently regress book-dp2-style projects. Pin the
+    // expected parts output with scope in the project config and assert
+    // it matches the same output without scope.
+    memfs.vol.fromJSON({ 'index.md': '', 'ch1.md': '', 'ch2.md': '' });
+    primeProjectConfig('.', {
+      numbering: {
+        book: { enabled: true },
+        proof: { scope: 'section' },
+      },
+    });
+    const proj = projectFromTOC(session, '.', [
+      { file: 'index' },
+      {
+        title: 'Theory',
+        section: 'parts',
+        children: [{ file: 'ch1' }, { file: 'ch2' }],
+      },
+    ]);
+    expect(simplifyPages(proj.pages)).toEqual([
+      { level: -1, section: 'parts', title: 'Part I — Theory' },
+      { file: 'ch1.md', slug: 'ch1', level: 0, section: 'chapters' },
+      { file: 'ch2.md', slug: 'ch2', level: 0, section: 'chapters' },
+    ]);
+  });
+
   it('no parts in TOC → top-level level stays at 1 (regression)', () => {
     // Existing TOCs without parts must not have their page levels shifted
     // by the parts auto-detection.

--- a/packages/myst-cli/src/project/fromTOC.ts
+++ b/packages/myst-cli/src/project/fromTOC.ts
@@ -377,9 +377,20 @@ export function projectFromTOC(
   return { path: path || '.', file: indexFile, index: slug, pages };
 }
 
+/**
+ * Walk the TOC for any entry that will actually emit a part divider.
+ * Must match the predicate in `pagesFromEntries` — `section: parts` only
+ * fires on a non-file, non-url ParentEntry. A FileEntry/URLEntry with
+ * `section: parts` is malformed and silently treated as a regular page
+ * (its `section` is downgraded to `'chapters'` by the parts→chapters
+ * child-default rule), so it must NOT trigger the level shift.
+ */
 function hasPartsSubtree(entries: EntryWithoutPattern[]): boolean {
   for (const entry of entries) {
-    if ((entry as { section?: BookSection }).section === 'parts') return true;
+    const isParentEntry = !isFile(entry) && !isURL(entry);
+    if (isParentEntry && (entry as { section?: BookSection }).section === 'parts') {
+      return true;
+    }
     const parent = entry as Partial<ParentEntry>;
     if (parent.children && hasPartsSubtree(parent.children as EntryWithoutPattern[])) {
       return true;

--- a/packages/myst-cli/src/project/fromTOC.ts
+++ b/packages/myst-cli/src/project/fromTOC.ts
@@ -33,6 +33,21 @@ import type {
 import { isFile, isPattern, isURL } from 'myst-toc';
 import { globSync } from 'glob';
 import { isDirectory } from 'myst-cli-utils';
+import { formatCounter } from 'myst-transforms';
+import type { CounterFormat } from 'myst-frontmatter';
+
+type PartCounter = { count: number };
+
+function formatPartTitle(
+  index: number,
+  rawTitle: string,
+  format: CounterFormat,
+  label: string,
+): string {
+  const formatted = formatCounter(index, format);
+  const heading = label.replace('%s', formatted);
+  return `${heading} — ${rawTitle}`;
+}
 
 export const DEFAULT_INDEX_FILENAMES = ['index', 'readme', 'main'];
 const DEFAULT_INDEX_WITH_EXT = ['.md', '.ipynb', '.myst.json']
@@ -170,14 +185,28 @@ function pagesFromEntries(
   pageSlugs: PageSlugs,
   opts?: SlugOptions,
   inheritedSection?: BookSection,
+  partCounter: PartCounter = { count: 0 },
 ): (LocalProjectFolder | LocalProjectPage)[] {
   const configFile = selectors.selectLocalConfigFile(session.store.getState(), path);
+  const projectConfig = selectors.selectLocalProjectConfig(session.store.getState(), path);
+  const numbering = projectConfig?.numbering;
+  const bookMode = numbering?.book?.enabled === true;
+  const partsFormat = (numbering?.parts?.format as CounterFormat | undefined) ?? 'Roman';
+  const partsLabel = numbering?.parts?.label ?? 'Part %s';
   for (const entry of entries) {
     let entryLevel = level;
     // A subtree with `section:` tags its descendants; siblings without it
     // keep the inherited value (so a top-level "Appendices" subtree wraps
     // every descendant page even if intermediate parents omit `section:`).
-    const childSection: BookSection | undefined = entry.section ?? inheritedSection;
+    // `section: parts` is special: the parts tag belongs to the divider
+    // itself, but descendants should inherit `section: chapters` (the
+    // dp2 convention — a part wraps chapters by default).
+    let childSection: BookSection | undefined;
+    if (entry.section === 'parts') {
+      childSection = 'chapters';
+    } else {
+      childSection = entry.section ?? inheritedSection;
+    }
     if (isFile(entry)) {
       // Level must be "chapter" (0) or "section" (1-6) for files
       entryLevel = level < 0 ? 0 : level;
@@ -206,13 +235,27 @@ function pagesFromEntries(
         open_in_same_tab: entry.open_in_same_tab,
       });
     } else {
-      // ParentEntry. A `section:`-tagged subtree is a *logical* group, not
-      // a structural one: it doesn't emit a folder entry and doesn't bump
-      // the heading depth for its children. Without this, the section
-      // subtree would behave like a part header — ch1's H1 would land at
-      // heading_2 instead of heading_1 and book-section defaults wouldn't
-      // line up with what authors actually wrote on the page.
-      if (entry.section) {
+      // ParentEntry. Three cases:
+      //  (a) section: 'parts' — structural divider. Emit a folder at
+      //      part-level (-1) with a formatted title ("Part I — Title")
+      //      and tag it section: 'parts'. Children bump to next level.
+      //  (b) other section tags — logical wrapper. No folder emitted,
+      //      no level bump. Without this, "Appendices" would behave
+      //      like a part header.
+      //  (c) no section tag — pre-existing folder behaviour (may be a
+      //      conventional part at level -1).
+      if (entry.section === 'parts') {
+        entryLevel = level < -1 ? -1 : level;
+        partCounter.count += 1;
+        const title = bookMode
+          ? formatPartTitle(partCounter.count, entry.title, partsFormat, partsLabel)
+          : entry.title;
+        pages.push({
+          level: entryLevel,
+          title,
+          section: 'parts',
+        });
+      } else if (entry.section) {
         // childSection is already entry.section (set above); fall through
         // to recurse with the same level.
       } else {
@@ -228,21 +271,28 @@ function pagesFromEntries(
     // Do we have any children?
     const parentEntry = entry as Partial<ParentEntry>;
     if (parentEntry.children) {
-      // Only a *section-only* ParentEntry (no `file:`) keeps its children
-      // at the same level — that's the "logical wrapper" intent. A
-      // section-tagged FileEntry with children is still a structural
+      // A *logical* section-only ParentEntry (no `file:`) keeps its
+      // children at the same level — that's the "logical wrapper" intent
+      // for chapters/appendices/frontmatter/backmatter.
+      //
+      // A `section: parts` ParentEntry is structural (a real divider with
+      // children at next level), so it does NOT count as a logical wrapper.
+      //
+      // A section-tagged FileEntry with children is still a structural
       // parent, so its children move to the next level (e.g. ch1.md's
       // sub-page becomes heading_2).
-      const isSectionGroup = !isFile(entry) && (entry as { section?: BookSection }).section;
+      const entrySection = (entry as { section?: BookSection }).section;
+      const isLogicalSectionGroup = !isFile(entry) && entrySection && entrySection !== 'parts';
       pagesFromEntries(
         session,
         path,
         parentEntry.children as EntryWithoutPattern[],
         pages,
-        isSectionGroup ? entryLevel : nextLevel(entryLevel),
+        isLogicalSectionGroup ? entryLevel : nextLevel(entryLevel),
         pageSlugs,
         opts,
         childSection,
+        partCounter,
       );
     }
   }
@@ -315,9 +365,27 @@ export function projectFromTOC(
   const slug = 'index';
   pageSlugs[slug] = 1;
 
+  // If the TOC declares any `section: 'parts'` subtree, start at level=-1
+  // so parts land at -1, chapters at 0 (page H1 → heading_1), and inner
+  // sections follow naturally. Without this, a parts divider at level=1
+  // would push chapter pages to level=2 and their H1 would render as
+  // heading_2 (e.g. "0.1") instead of heading_1 ("1").
+  const tocLevel: PageLevels = hasPartsSubtree(entries) ? -1 : level;
+
   const pages: (LocalProjectFolder | LocalProjectPage)[] = [];
-  pagesFromEntries(session, path, entries, pages, level, pageSlugs, opts);
+  pagesFromEntries(session, path, entries, pages, tocLevel, pageSlugs, opts);
   return { path: path || '.', file: indexFile, index: slug, pages };
+}
+
+function hasPartsSubtree(entries: EntryWithoutPattern[]): boolean {
+  for (const entry of entries) {
+    if ((entry as { section?: BookSection }).section === 'parts') return true;
+    const parent = entry as Partial<ParentEntry>;
+    if (parent.children && hasPartsSubtree(parent.children as EntryWithoutPattern[])) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function pagesFromSphinxChapters(

--- a/packages/myst-toc/src/toc.ts
+++ b/packages/myst-toc/src/toc.ts
@@ -23,7 +23,7 @@ import {
   validateChoice,
 } from 'simple-validators';
 
-const BOOK_SECTION_CHOICES = ['frontmatter', 'chapters', 'appendices', 'backmatter'];
+const BOOK_SECTION_CHOICES = ['frontmatter', 'parts', 'chapters', 'appendices', 'backmatter'];
 const COMMON_ENTRY_KEYS = ['title', 'hidden', 'section'];
 // const COMMON_ENTRY_KEYS = ['title', 'hidden', 'section', 'numbering', 'id', 'class'];
 

--- a/packages/myst-toc/src/types.ts
+++ b/packages/myst-toc/src/types.ts
@@ -3,8 +3,12 @@
  * `section`-tagged subtree inherit the section's numbering defaults
  * (chapters → arabic, appendices → Alph, etc.) once `numbering.book: true`
  * is set on the project.
+ *
+ * `parts` is structural — it emits a divider with a Roman-numeralled title
+ * ("Part I — General Theory") and its children default to `section: chapters`.
+ * The other sections are logical wrappers (no divider, same level).
  */
-export type BookSection = 'frontmatter' | 'chapters' | 'appendices' | 'backmatter';
+export type BookSection = 'frontmatter' | 'parts' | 'chapters' | 'appendices' | 'backmatter';
 
 /**
  * Common attributes for all TOC items

--- a/packages/myst-toc/src/types.ts
+++ b/packages/myst-toc/src/types.ts
@@ -4,7 +4,7 @@
  * (chapters → arabic, appendices → Alph, etc.) once `numbering.book: true`
  * is set on the project.
  *
- * `parts` is structural — it emits a divider with a Roman-numeralled title
+ * `parts` is structural — it emits a divider with a Roman-numbered title
  * ("Part I — General Theory") and its children default to `section: chapters`.
  * The other sections are logical wrappers (no divider, same level).
  */

--- a/packages/myst-toc/tests/examples.spec.ts
+++ b/packages/myst-toc/tests/examples.spec.ts
@@ -153,7 +153,7 @@ describe.each([
 });
 
 describe('book section field', () => {
-  test.each(['frontmatter', 'chapters', 'appendices', 'backmatter'])(
+  test.each(['frontmatter', 'parts', 'chapters', 'appendices', 'backmatter'])(
     'section: %s parses on a ParentEntry',
     (section) => {
       const input = [


### PR DESCRIPTION
## Summary

Adds `section: parts` to the book-numbering feature. A `section: parts` ParentEntry emits a Roman-numbered divider folder ("Part I — Theory") and wraps a group of chapters. The chapter counter continues across part boundaries — Ch 5 → Part II → Ch 6 — matching the LaTeX `book` default and unblocking dp2-style books.

This extends `qe-v2` (book-numbering) to cover the part-divider structure flagged as the one remaining gap for dp2.

## Behaviour

| Input | Output |
|---|---|
| `section: parts` ParentEntry | `LocalProjectFolder` at level -1, title `"Part I — <title>"`, `section: 'parts'` |
| Children of a parts subtree | Default to `section: chapters` (overridable per child); land at level 0 |
| Multiple parts in TOC | Roman counter increments I → II → … |
| `numbering.parts.format` | Overrides Roman default (e.g., `arabic` → `Part 1 …`) |
| `numbering.parts.label` | Overrides `"Part %s"` template (e.g., `"Book %s"` → `Book I …`) |
| `numbering.book` unset | No formatting; raw title used (backwards-compatible) |
| TOC without parts | `level` defaults to 1 unchanged (regression check) |

## Implementation

- **`myst-toc`** — extend `BookSection` with `'parts'`; add to `BOOK_SECTION_CHOICES` for validation.
- **`myst-cli/fromTOC.ts`**:
  - `formatPartTitle()` builds `"Part {Roman} — {title}"` using `formatCounter` from `myst-transforms`.
  - `pagesFromEntries` threads a mutable `PartCounter` through recursion; section `parts` increments and emits a structural folder; section `parts` children inherit `section: 'chapters'` by default.
  - `hasPartsSubtree()` auto-detects parts in the TOC and starts `projectFromTOC` at `level=-1` so chapters land at heading_1 (not heading_2).
- **Demo** — [quantecon/demo-book-parts](quantecon/demo-book-parts) (gitignored scratch) exercises two parts × two chapters + an appendix and verifies dp2-style numbering end-to-end.

## Verified output (from the local demo)

```
Part I — Theory          (folder, level=-1, section=parts)
  ch1                    enumerator=1   → "Chapter 1 Introduction"
  ch2                    enumerator=2   → "Chapter 2 Theory"
Part II — Applications   (folder, level=-1, section=parts)
  ch3                    enumerator=3   → "Chapter 3 Applications"   ← continues across parts
  ch4                    enumerator=4   → "Chapter 4 Extensions"
app-a                    enumerator=A   → "Appendix A"               ← Alph counter unaffected
```

Figures auto-prefix correctly: `fig-intro=1.1`, `fig-theory=2.1`, `fig-applications=3.1`.

## Tests

- **8 new unit tests** in `packages/myst-cli/src/project/fromTOC.parts.spec.ts` covering folder emission, counter-across-parts, format/label overrides, book-mode gating, child-section default, parts+appendices coexistence, and the no-parts regression.
- **myst-toc** parametric test now covers `'parts'`.
- All pre-existing project tests (69) still pass. The 5 failing tests in `resolveTemplate` / `resolveArticles` were already failing on `main` before this PR.

## Scope intentionally deferred

- `reset_on_part: true` (Quarto-style chapter reset on part entry) — schema accepts it; not consumed.
- Standalone part-divider pages (synthetic .md content for PDF rendering) — sidebar-only for now, sufficient for web-first books like QuantEcon's.
- Cross-refs to parts (`[](#part-1)`) — would need `id:` on ParentEntry; follow-up if needed.

## Test plan

- [ ] CI passes (lint, docs build, bun + node 20/22/24)
- [ ] Local: `cd quantecon/demo-book-parts && myst build --site` produces the table above
- [ ] After merge: tag `qe-v3`, bump `quantecon/VERSION.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)