### PR TITLE
chore(quantecon): cut qe-v3 (book-proof-scope, #28)

### DIFF
--- a/quantecon/README.md
+++ b/quantecon/README.md
@@ -15,13 +15,15 @@ Two tracked YAML files in `quantecon/` record orthogonal facts. Keep them in syn
 
 ### Maintaining `VERSION.yml`
 
-Every time a feature PR lands on `main`, append a row to `merged_features` with its squash `merge_sha`. The `tag` field stays null until the next `qe-v<N>` checkpoint.
+Every time a feature PR lands on `main`, append a row to `merged_features` with its squash `merge_sha`. The `tag` field stays null until a `qe-v<N>` tag is cut over that feature.
 
-Tags are cut at meaningful checkpoints, **not per-PR** — typically when a batch of features is ready for downstream dogfooding. To cut a tag:
+Tags can be cut per-PR (one tag per feature, easy traceability) or batched at a checkpoint (one tag covering several merged features ready for downstream dogfooding) — pick whichever fits the cadence. To cut a tag, do the metadata update *first* so the tagged commit's tree is self-consistent:
 
-1. Pick the `main` commit at the head of the batch
-2. Tag it: `git tag qe-v<N+1> <sha> -m "qe-v<N+1>: <summary of features included>"` then `git push origin qe-v<N+1>`
-3. Set `tag: qe-v<N+1>` on each newly-included feature in `merged_features` and bump `qe_version`
+1. Open a doc PR updating `VERSION.yml`: bump `qe_version` to `qe-v<N+1>` and set `tag: qe-v<N+1>` on each previously-untagged entry in `merged_features` that is included in this tag.
+2. Squash-merge the doc PR.
+3. Tag the resulting `main` commit: `git tag qe-v<N+1> <sha> -m "qe-v<N+1>: <summary>"` then `git push origin qe-v<N+1>`.
+
+Doing it in this order means anyone who `cat`s `VERSION.yml` at tag `qe-v<N+1>` sees a self-consistent file (qe_version field matches the tag).
 
 ### Maintaining `UPSTREAM-PRS.yml`
 

--- a/quantecon/VERSION.yml
+++ b/quantecon/VERSION.yml
@@ -24,7 +24,7 @@
 #      `merged_features` that is included in the batch, then bump
 #      `qe_version` to `qe-v<N+1>`
 
-qe_version: qe-v2
+qe_version: qe-v3
 upstream_base: 1.9.0
 
 merged_features:
@@ -47,4 +47,4 @@ merged_features:
     description: Section-level scope for proof:* / figure / equation auto-prefix
     local_pr: 28
     merge_sha: 80bb9ecf
-    tag: null      # cut at next qe-v<N> checkpoint
+    tag: qe-v3


### PR DESCRIPTION
## Summary

Cuts the `qe-v3` integration tag covering PR #28 (book-proof-scope). Per the freshly-updated [`quantecon/README.md`](quantecon/README.md) maintaining-VERSION.yml workflow: the doc PR lands *first*, then the git tag is cut on the merged commit so `cat VERSION.yml` at the tag is self-consistent.

## Changes

- [`quantecon/VERSION.yml`](quantecon/VERSION.yml): bump `qe_version` to `qe-v3`; set `tag: qe-v3` on the `book-proof-scope` entry (id: 3).
- [`quantecon/README.md`](quantecon/README.md): clarify the tag-cut workflow — VERSION.yml update goes via PR first, *then* the tag is cut on the merged commit. Also relaxes "must be batched" to "per-PR or batched, pick whichever fits the cadence" (qe-v3 covers a single feature; future tags may bundle).

PR #26 (book-parts) is still open and will become `qe-v4` once it merges.

## Post-merge steps (manual)

After squash-merging this PR:
```bash
git checkout main && git pull
git tag qe-v3 HEAD -m "qe-v3: book-proof-scope (#28)"
git push origin qe-v3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)