### PR TITLE
chore(quantecon): cut qe-v4 (book-parts, #26)

### DIFF
--- a/quantecon/README.md
+++ b/quantecon/README.md
@@ -17,7 +17,7 @@ Two tracked YAML files in `quantecon/` record orthogonal facts. Keep them in syn
 
 Every time a feature PR lands on `main`, append a row to `merged_features` with its squash `merge_sha`. The `tag` field stays null until a `qe-v<N>` tag is cut over that feature.
 
-Tags can be cut per-PR (one tag per feature, easy traceability) or batched at a checkpoint (one tag covering several merged features ready for downstream dogfooding) — pick whichever fits the cadence. To cut a tag, do the metadata update *first* so the tagged commit's tree is self-consistent:
+Tags can be cut per-PR (one tag per feature, easy traceability) or batched at a checkpoint (one tag covering several merged features ready to deploy to book-dp1 / book-dp2 for testing) — pick whichever fits the cadence. To cut a tag, do the metadata update *first* so the tagged commit's tree is self-consistent:
 
 1. Open a doc PR updating `VERSION.yml`: bump `qe_version` to `qe-v<N+1>` and set `tag: qe-v<N+1>` on each previously-untagged entry in `merged_features` that is included in this tag.
 2. Squash-merge the doc PR.

--- a/quantecon/UPSTREAM-PRS.yml
+++ b/quantecon/UPSTREAM-PRS.yml
@@ -75,8 +75,11 @@ upstream_candidates:
       `section: parts` ParentEntry: emits a Roman-numbered divider folder
       ("Part I — Theory") and wraps chapter groups. Chapter counter
       continues across part boundaries (LaTeX `book` default).
-    status: planned   # PR #26 still open against our main
-    commits: []       # populated once #26 squash-merges into main
+    status: pending
+    commits:
+      - sha: 5edc040d
+        local_pr: 26
+        title: "Book parts: section: parts dividers with Roman labels"
     depends_on:
       - book-mode-with-section-scope
     upstream:

--- a/quantecon/VERSION.yml
+++ b/quantecon/VERSION.yml
@@ -15,16 +15,24 @@
 # `merge_sha` and `tag: null`. The `tag:` field is filled in later when a
 # `qe-vN` tag is cut.
 #
-# Tags are cut at meaningful checkpoints (typically when a batch of
-# features is ready for downstream dogfooding), **not per-PR**. When
-# cutting a tag:
-#   1. Pick the `main` commit at the head of the batch
-#   2. Tag it `qe-v<N+1>` and push the tag
-#   3. Set `tag: qe-v<N+1>` on each previously-untagged entry in
-#      `merged_features` that is included in the batch, then bump
-#      `qe_version` to `qe-v<N+1>`
+# Tags can be cut per-PR (one tag per feature, easy traceability) or
+# batched at a checkpoint (one tag covering several merged features
+# ready to deploy to book-dp1 / book-dp2 for testing) — pick whichever
+# fits the cadence.
+# To cut a tag, do the metadata update *first* so the tagged commit's
+# tree is self-consistent:
+#   1. Open a doc PR updating this file: bump `qe_version` to `qe-v<N+1>`
+#      and set `tag: qe-v<N+1>` on each previously-untagged entry in
+#      `merged_features` that is included in this tag.
+#   2. Squash-merge the doc PR.
+#   3. Tag the resulting `main` commit:
+#         git tag qe-v<N+1> <sha> -m "qe-v<N+1>: <summary>"
+#         git push origin qe-v<N+1>
+#
+# Doing it in this order means anyone who `cat`s VERSION.yml at tag
+# `qe-v<N+1>` sees a self-consistent file (qe_version matches the tag).
 
-qe_version: qe-v3
+qe_version: qe-v4
 upstream_base: 1.9.0
 
 merged_features:
@@ -48,3 +56,10 @@ merged_features:
     local_pr: 28
     merge_sha: 80bb9ecf
     tag: qe-v3
+
+  - id: 4
+    name: book-parts
+    description: Book parts dividers (Roman-numbered) with continuous chapter counter
+    local_pr: 26
+    merge_sha: 5edc040d
+    tag: qe-v4


### PR DESCRIPTION
## Summary

Cuts the `qe-v4` integration tag covering PR #26 (book-parts). Follows the [`quantecon/README.md`](quantecon/README.md) tag-cut workflow: doc PR first, then `git tag` on the merged commit.

## Changes

- [`quantecon/VERSION.yml`](quantecon/VERSION.yml):
  - Bump `qe_version` to `qe-v4`
  - Add new entry `id: 4, name: book-parts` with `merge_sha: 5edc040d` and `tag: qe-v4`
  - Sync the header comment to the new tag-cut workflow (was still describing the legacy "tag-first" order and "batched not per-PR" convention)
- [`quantecon/UPSTREAM-PRS.yml`](quantecon/UPSTREAM-PRS.yml):
  - Move `book-parts` candidate from `status: planned` → `pending`
  - Fill in its `commits` list with the now-known squash sha

## Current main feature timeline

| Tag | Feature | PR | Squash SHA |
|-----|---------|----|------------|
| qe-v1 | myst-to-ipynb | #16 | a045d57d |
| qe-v2 | book-numbering | #22 | 032957c2 |
| qe-v3 | book-proof-scope | #28 | 80bb9ecf |
| qe-v4 | book-parts | #26 | 5edc040d |

## Post-merge step (manual)

```bash
git checkout main && git pull
git tag qe-v4 HEAD -m "qe-v4: book-parts (#26)"
git push origin qe-v4
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)