### PR TITLE
chore(quantecon): track qe-v5 (book-section-heading-chain, #33)

### DIFF
--- a/quantecon/UPSTREAM-PRS.yml
+++ b/quantecon/UPSTREAM-PRS.yml
@@ -60,6 +60,9 @@ upstream_candidates:
       - sha: 80bb9ecf
         local_pr: 28
         title: "feat(book): section-level scope for proof:* / figure / equation auto-prefix"
+      - sha: 043ddcb5
+        local_pr: 33
+        title: "feat(book): full title→heading chain in injectBookSectionDefaults"
     depends_on: []
     upstream:
       pr: null
@@ -67,7 +70,10 @@ upstream_candidates:
       merged_sha: null
     notes: |
       Could be split into two upstream PRs if maintainers prefer smaller
-      reviews; default plan is one bundled PR.
+      reviews; default plan is one bundled PR. #33 is a direct follow-up
+      to #22's injectBookSectionDefaults (extends the per-section wiring
+      from heading_1 to the full title→heading_1..6 chain) — naturally
+      part of the same upstream story.
 
   - id: book-parts
     title: Book parts dividers

--- a/quantecon/VERSION.yml
+++ b/quantecon/VERSION.yml
@@ -32,7 +32,7 @@
 # Doing it in this order means anyone who `cat`s VERSION.yml at tag
 # `qe-v<N+1>` sees a self-consistent file (qe_version matches the tag).
 
-qe_version: qe-v4
+qe_version: qe-v5
 upstream_base: 1.9.0
 
 merged_features:
@@ -63,3 +63,10 @@ merged_features:
     local_pr: 26
     merge_sha: 5edc040d
     tag: qe-v4
+
+  - id: 5
+    name: book-section-heading-chain
+    description: Full title→heading_1..6 chain per section in injectBookSectionDefaults
+    local_pr: 33
+    merge_sha: 043ddcb5
+    tag: qe-v5


### PR DESCRIPTION
## Summary

- Records PR #33 (`feat(book): full title→heading chain in injectBookSectionDefaults`) in [`quantecon/VERSION.yml`](quantecon/VERSION.yml) — bumps `qe_version` to `qe-v5` and appends `merged_features` id 5 with `tag: qe-v5`.
- Adds `043ddcb5` to the `book-mode-with-section-scope` upstream candidate in [`quantecon/UPSTREAM-PRS.yml`](quantecon/UPSTREAM-PRS.yml). Rationale: #33 patches #22's `injectBookSectionDefaults` (extends the per-section wiring from `heading_1` to the full `title → heading_1..6` chain) — it's the same machinery and belongs in the same upstream story.

#33 was merged onto `main` after qe-v4 but skipped the metadata append step. This brings tracking back in sync.

## Tag

After squash-merge, tag the resulting commit:

```
git tag qe-v5 <merge-sha> -m "qe-v5: book-section-heading-chain (#33)"
git push origin qe-v5
```

(Same pattern as #31 → qe-v3 and #32 → qe-v4.)

## Test plan

- [x] `VERSION.yml` is self-consistent at the post-merge tag: `qe_version: qe-v5` matches the new id 5 entry's `tag: qe-v5`.
- [x] Every `merge_sha` in `VERSION.yml` appears in some upstream candidate's `commits` list in `UPSTREAM-PRS.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)