### PR TITLE
chore(quantecon): track qe-v6 (book-proof-counter-share, #40)

### DIFF
--- a/quantecon/UPSTREAM-PRS.yml
+++ b/quantecon/UPSTREAM-PRS.yml
@@ -43,15 +43,18 @@ upstream_candidates:
       Self-contained; can ship upstream any time.
 
   - id: book-mode-with-section-scope
-    title: Book-style numbering (with LaTeX-style section scope)
+    title: Book-style numbering (with LaTeX-style section scope and counter sharing)
     description: |
       Bundles the original book-mode work (#22) with the section-scope
-      extension (#28). The two form one coherent story upstream — #28
-      builds on #22's auto-prefix machinery (`shouldAutoPrefix`,
-      `AUTO_PREFIX_KINDS`, the `numbering.book` flag) and is a small
-      targeted extension of it. Shipping them as one upstream PR avoids
-      the awkward two-step where reviewers see the section-scope hook
-      points before the machinery exists.
+      extension (#28), the heading-chain follow-up (#33), and the
+      shared-counter extension (#40). All four form one coherent story
+      upstream — #28 builds on #22's auto-prefix machinery
+      (`shouldAutoPrefix`, `AUTO_PREFIX_KINDS`, the `numbering.book`
+      flag), #33 extends #22's `injectBookSectionDefaults`, and #40
+      adds the `counter:` alias that completes LaTeX-`\newtheorem`
+      parity on top of #28's `scope:`. Shipping them as one upstream
+      PR avoids the awkward two-step where reviewers see hook points
+      before the machinery exists.
     status: pending
     commits:
       - sha: 032957c2
@@ -63,17 +66,23 @@ upstream_candidates:
       - sha: 043ddcb5
         local_pr: 33
         title: "feat(book): full title→heading chain in injectBookSectionDefaults"
+      - sha: a63d53f1
+        local_pr: 40
+        title: "feat(book): shared counters across proof:* kinds (#34)"
     depends_on: []
     upstream:
       pr: null
       branch: null
       merged_sha: null
     notes: |
-      Could be split into two upstream PRs if maintainers prefer smaller
-      reviews; default plan is one bundled PR. #33 is a direct follow-up
-      to #22's injectBookSectionDefaults (extends the per-section wiring
-      from heading_1 to the full title→heading_1..6 chain) — naturally
-      part of the same upstream story.
+      Could be split into smaller upstream PRs if maintainers prefer;
+      default plan is one bundled PR. #33 is a direct follow-up to
+      #22's injectBookSectionDefaults (extends the per-section wiring
+      from heading_1 to the full title→heading_1..6 chain). #40 is a
+      direct follow-up to #28's section-scope work — it closes the
+      residual counter-share gap so interleaved theorem/lemma/proposition
+      enumerators match the LaTeX PDF (LaTeX `\newtheorem{lemma}[theorem]`
+      parity). Naturally part of the same upstream story.
 
   - id: book-parts
     title: Book parts dividers

--- a/quantecon/VERSION.yml
+++ b/quantecon/VERSION.yml
@@ -32,7 +32,7 @@
 # Doing it in this order means anyone who `cat`s VERSION.yml at tag
 # `qe-v<N+1>` sees a self-consistent file (qe_version matches the tag).
 
-qe_version: qe-v5
+qe_version: qe-v6
 upstream_base: 1.9.1
 
 merged_features:
@@ -70,3 +70,10 @@ merged_features:
     local_pr: 33
     merge_sha: 043ddcb5
     tag: qe-v5
+
+  - id: 6
+    name: book-proof-counter-share
+    description: Shared counters across proof:* kinds (LaTeX \newtheorem[<other>] parity)
+    local_pr: 40
+    merge_sha: a63d53f1
+    tag: qe-v6


### PR DESCRIPTION
## Summary

- Bumps `qe_version: qe-v6` in [`quantecon/VERSION.yml`](quantecon/VERSION.yml).
- Appends `id: 6` (`book-proof-counter-share`, local PR #40, merge_sha `a63d53f1`, tag `qe-v6`) to `merged_features`.
- Adds the #40 squash SHA to the existing `book-mode-with-section-scope` upstream candidate in [`quantecon/UPSTREAM-PRS.yml`](quantecon/UPSTREAM-PRS.yml). #40 is the direct counter-share extension of #28's `scope: section` work — bundling them keeps the upstream narrative coherent (auto-prefix machinery → section-scope → heading chain → counter sharing).

## Tagging

Per the workflow in `VERSION.yml`'s preamble — once this PR is squash-merged, cut the tag on the resulting `main` commit:

```bash
git tag qe-v6 <sha> -m "qe-v6: book-proof-counter-share"
git push origin qe-v6
```

The doc update runs first so anyone who `cat`s `VERSION.yml` at the `qe-v6` tag sees a self-consistent file (`qe_version: qe-v6` matches the tag).

## Test plan

- [x] VERSION.yml `qe_version` bumped and id 6 entry appended with correct squash SHA
- [x] UPSTREAM-PRS.yml `book-mode-with-section-scope` candidate updated with #40's commit + description/notes reflect the now-larger bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)