### PR TITLE
chore(quantecon): track id 7 (cli-show-qe-version, #42)

### DIFF
--- a/quantecon/VERSION.yml
+++ b/quantecon/VERSION.yml
@@ -77,3 +77,10 @@ merged_features:
     local_pr: 40
     merge_sha: a63d53f1
     tag: qe-v6
+
+  - id: 7
+    name: cli-show-qe-version
+    description: Show qe-vN identifier in `myst --version` output (fork-only tooling, not for upstream)
+    local_pr: 42
+    merge_sha: 95494e41
+    tag: null


### PR DESCRIPTION
## Summary

Appends id 7 (`cli-show-qe-version`, local PR #42, merge_sha `95494e41`, `tag: null`) to `quantecon/VERSION.yml > merged_features`. No `qe_version` bump, no `UPSTREAM-PRS.yml` change.

## Why no upstream entry

PR #42 adds fork-only build tooling (the `myst --version` output gain `(qe-vN)` only makes sense in the QuantEcon fork — upstream has no `qe_version` concept and no `quantecon/VERSION.yml`). Same shape as earlier fork-tooling commits (#14, #23, #24) which never appeared in any upstream candidate.

## Why no `qe_version` bump

`qe_version` records the most recent **checkpoint** tag, not the most recent commit. PR #42 lands but the next checkpoint is deferred — qe-v7 will be cut later, either dedicated to #42 or batched with the next feature PR. The header docs in [`VERSION.yml`](quantecon/VERSION.yml) explicitly support both cadences. The `tag: null` placeholder on id 7 gets filled in when that tag is cut.

## Test plan

- [x] id 7 appended with correct squash SHA (`95494e41`)
- [x] `tag: null` (deferred)
- [x] No `qe_version` change
- [x] No `UPSTREAM-PRS.yml` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)