### PR TITLE
chore: sync fork with upstream jupyter-book/mystmd (16 commits)

### DIFF
--- a/.changeset/chubby-nails-look.md
+++ b/.changeset/chubby-nails-look.md
@@ -1,0 +1,7 @@
+---
+'myst-to-typst': patch
+'myst-cli': patch
+'mystmd': patch
+---
+
+Fix \left| and \right| delimeters (rely on upstream fix in tex-to-typst)

--- a/.changeset/citation-html-stop.md
+++ b/.changeset/citation-html-stop.md
@@ -1,0 +1,5 @@
+---
+"markdown-it-myst": patch
+---
+
+Stop citation label parsing at `<` so following HTML and autolinks are preserved

--- a/.changeset/fine-meals-fall.md
+++ b/.changeset/fine-meals-fall.md
@@ -1,0 +1,6 @@
+---
+"myst-cli": patch
+"myst-execute": patch
+---
+
+Only copy thebe JS when necessary

--- a/.changeset/index-redirect-head-end.md
+++ b/.changeset/index-redirect-head-end.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'mystmd': patch
+---
+
+Append the index-redirect script to the end of `<head>` instead of the beginning, so other site `<head>` content (e.g. preloads, meta tags) is not affected by the script's placement.

--- a/.changeset/legal-flowers-drum.md
+++ b/.changeset/legal-flowers-drum.md
@@ -1,0 +1,5 @@
+---
+'myst-to-typst': patch
+---
+
+Add passthrough `card` wrapping the card content such that custom styling can be applied by the `typst` template

--- a/.changeset/lemon-houses-retire.md
+++ b/.changeset/lemon-houses-retire.md
@@ -1,0 +1,8 @@
+---
+'myst-execute': minor
+'myst-frontmatter': minor
+'myst-config': minor
+'myst-cli': minor
+---
+
+Add static_files option to project frontmatter for copying files into build output with stable URLs

--- a/.changeset/public-worms-kiss.md
+++ b/.changeset/public-worms-kiss.md
@@ -1,0 +1,7 @@
+---
+'myst-migrate': patch
+'myst-cli': patch
+'mystmd': patch
+---
+
+Allow for myst.yaml as well as myst.yml.

--- a/.changeset/salty-oranges-teach.md
+++ b/.changeset/salty-oranges-teach.md
@@ -1,0 +1,5 @@
+---
+"myst-execute": patch
+---
+
+Choose a random port on execution

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
-*.md
 worktrees/

--- a/.github/workflows/check-release-pr.yml
+++ b/.github/workflows/check-release-pr.yml
@@ -1,0 +1,26 @@
+name: Check Release PR
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-mystmd-bump:
+    name: Ensure release PR bumps mystmd
+    if: github.head_ref == 'changeset-release/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      # If `mystmd`'s version didn't change, no new `mystmd` will be released.
+      # So this checks that the .json has been updated, and if not raises an error to
+      # make sure the merger does this intentionally!
+      - name: Compare mystmd version on main vs this PR
+        run: |
+          old=$(git show HEAD^1:packages/mystmd/package.json | jq -r .version)
+          new=$(jq -r .version packages/mystmd/package.json)
+          if [ "$old" = "$new" ]; then
+            echo "::error::No changeset bumps 'mystmd' or 'myst-cli' (mystmd still $old). See https://mystmd.org/guide/developer#changesets-myst-cli"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ yalc.lock
 
 # vim swap files
 *.swp
+
+# git worktrees
+worktrees/

--- a/bun.lock
+++ b/bun.lock
@@ -97,7 +97,7 @@
     },
     "packages/myst-cli": {
       "name": "myst-cli",
-      "version": "1.8.2",
+      "version": "1.9.1",
       "dependencies": {
         "@jupyterlab/services": "^7.3.0",
         "@reduxjs/toolkit": "^2.1.0",
@@ -126,31 +126,32 @@
         "mdast": "^3.0.0",
         "meca": "^1.0.8",
         "mime-types": "^2.1.35",
-        "myst-cli-utils": "^2.0.13",
+        "myst-cli-utils": "^2.0.14",
         "myst-common": "^1.9.5",
         "myst-config": "^1.9.5",
-        "myst-execute": "^0.3.3",
+        "myst-execute": "^0.3.5",
         "myst-ext-button": "^0.0.1",
         "myst-ext-card": "^1.0.9",
         "myst-ext-exercise": "^1.0.9",
-        "myst-ext-grid": "^1.0.9",
+        "myst-ext-grid": "^1.1.0",
         "myst-ext-icon": "^0.0.2",
         "myst-ext-proof": "^1.0.12",
         "myst-ext-reactive": "^1.0.9",
         "myst-ext-tabs": "^1.0.9",
         "myst-frontmatter": "^1.9.5",
-        "myst-migrate": "^1.8.2",
-        "myst-parser": "^1.7.0",
+        "myst-migrate": "^1.9.1",
+        "myst-parser": "^1.7.2",
         "myst-spec": "^0.0.5",
         "myst-spec-ext": "^1.9.5",
         "myst-templates": "^1.0.27",
         "myst-to-docx": "^1.0.16",
+        "myst-to-ipynb": "^1.0.15",
         "myst-to-jats": "^1.0.35",
         "myst-to-md": "^1.0.16",
-        "myst-to-tex": "^1.0.45",
-        "myst-to-typst": "^0.0.36",
+        "myst-to-tex": "^1.0.46",
+        "myst-to-typst": "^0.0.37",
         "myst-toc": "^0.1.4",
-        "myst-transforms": "^1.3.47",
+        "myst-transforms": "^1.3.49",
         "nanoid": "^5.1.6",
         "nbtx": "^0.4.0",
         "node-fetch": "^3.3.1",
@@ -159,7 +160,7 @@
         "redux": "^5.0.1",
         "simple-validators": "^1.2.0",
         "strip-ansi": "^7.0.1",
-        "tex-to-myst": "^1.0.45",
+        "tex-to-myst": "^1.0.46",
         "unified": "^10.1.2",
         "unist-util-filter": "^4.0.0",
         "unist-util-remove": "^3.1.0",
@@ -189,7 +190,7 @@
     },
     "packages/myst-cli-utils": {
       "name": "myst-cli-utils",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "dependencies": {
         "chalk": "^5.2.0",
         "pretty-hrtime": "^1.0.3",
@@ -236,7 +237,7 @@
     },
     "packages/myst-directives": {
       "name": "myst-directives",
-      "version": "1.7.0",
+      "version": "1.7.2",
       "dependencies": {
         "classnames": "^2.3.2",
         "csv-parse": "^5.5.5",
@@ -251,11 +252,12 @@
     },
     "packages/myst-execute": {
       "name": "myst-execute",
-      "version": "0.3.3",
+      "version": "0.3.5",
       "dependencies": {
         "@jupyterlab/nbformat": "^3.5.2",
         "@jupyterlab/services": "^7.3.0",
         "chalk": "^5.2.0",
+        "get-port": "^6.1.2",
         "myst-cli-utils": "^2.0.13",
         "myst-common": "^1.9.3",
         "node-fetch": "^3.3.0",
@@ -300,12 +302,12 @@
     },
     "packages/myst-ext-grid": {
       "name": "myst-ext-grid",
-      "version": "1.0.9",
+      "version": "1.1.0",
       "dependencies": {
         "myst-common": "^1.7.2",
       },
       "devDependencies": {
-        "myst-parser": "^1.5.9",
+        "myst-parser": "^1.7.1",
       },
     },
     "packages/myst-ext-icon": {
@@ -370,7 +372,7 @@
     },
     "packages/myst-migrate": {
       "name": "myst-migrate",
-      "version": "1.8.2",
+      "version": "1.9.1",
       "dependencies": {
         "unist-util-select": "^4.0.3",
         "unist-util-visit": "^4.1.2",
@@ -383,7 +385,7 @@
     },
     "packages/myst-parser": {
       "name": "myst-parser",
-      "version": "1.7.0",
+      "version": "1.7.2",
       "dependencies": {
         "@types/markdown-it": "^13.0.0",
         "he": "^1.2.0",
@@ -397,8 +399,8 @@
         "markdown-it-myst-extras": "0.3.0",
         "markdown-it-task-lists": "^2.1.1",
         "myst-common": "^1.9.5",
-        "myst-directives": "^1.7.0",
-        "myst-roles": "^1.7.0",
+        "myst-directives": "^1.7.2",
+        "myst-roles": "^1.7.2",
         "myst-spec": "^0.0.5",
         "unified": "^10.1.1",
         "unist-builder": "^3.0.0",
@@ -414,14 +416,14 @@
         "@types/js-yaml": "^4.0.5",
         "@types/mdast": "^3.0.10",
         "js-yaml": "^4.1.0",
-        "myst-to-html": "^1.7.0",
-        "myst-transforms": "^1.3.47",
+        "myst-to-html": "^1.7.2",
+        "myst-transforms": "^1.3.49",
         "rehype-stringify": "^9.0.3",
       },
     },
     "packages/myst-roles": {
       "name": "myst-roles",
-      "version": "1.7.0",
+      "version": "1.7.2",
       "dependencies": {
         "myst-common": "^1.9.5",
         "myst-spec-ext": "^1.9.5",
@@ -480,7 +482,7 @@
     },
     "packages/myst-to-html": {
       "name": "myst-to-html",
-      "version": "1.7.0",
+      "version": "1.7.2",
       "dependencies": {
         "@types/markdown-it": "^13.0.1",
         "classnames": "^2.3.2",
@@ -504,6 +506,22 @@
       },
       "devDependencies": {
         "hastscript": "^7.0.0",
+      },
+    },
+    "packages/myst-to-ipynb": {
+      "name": "myst-to-ipynb",
+      "version": "1.0.15",
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "mdast-util-gfm-footnote": "^1.0.2",
+        "mdast-util-gfm-table": "^1.0.7",
+        "mdast-util-to-markdown": "^1.5.0",
+        "myst-common": "^1.7.6",
+        "myst-frontmatter": "^1.7.6",
+        "myst-to-md": "^1.0.15",
+        "unist-util-select": "^4.0.3",
+        "vfile": "^5.3.7",
+        "vfile-reporter": "^7.0.4",
       },
     },
     "packages/myst-to-jats": {
@@ -555,7 +573,7 @@
     },
     "packages/myst-to-tex": {
       "name": "myst-to-tex",
-      "version": "1.0.45",
+      "version": "1.0.46",
       "dependencies": {
         "myst-common": "^1.9.4",
         "myst-ext-proof": "^1.0.11",
@@ -566,17 +584,17 @@
         "vfile-reporter": "^7.0.4",
       },
       "devDependencies": {
-        "myst-parser": "^1.6.4",
+        "myst-parser": "^1.7.1",
       },
     },
     "packages/myst-to-typst": {
       "name": "myst-to-typst",
-      "version": "0.0.36",
+      "version": "0.0.37",
       "dependencies": {
         "myst-common": "^1.9.4",
         "myst-frontmatter": "^1.9.4",
         "myst-spec-ext": "^1.9.4",
-        "tex-to-typst": "^0.0.18",
+        "tex-to-typst": "^0.0.20",
         "unist-util-select": "^4.0.3",
         "vfile-reporter": "^7.0.4",
       },
@@ -590,7 +608,7 @@
     },
     "packages/myst-transforms": {
       "name": "myst-transforms",
-      "version": "1.3.47",
+      "version": "1.3.49",
       "dependencies": {
         "doi-utils": "^2.0.5",
         "hast-util-from-html": "^2.0.1",
@@ -603,7 +621,7 @@
         "myst-frontmatter": "^1.9.5",
         "myst-spec": "^0.0.5",
         "myst-spec-ext": "^1.9.5",
-        "myst-to-html": "1.7.0",
+        "myst-to-html": "1.7.2",
         "rehype-parse": "^8.0.4",
         "rehype-remark": "^9.1.2",
         "unified": "^10.0.0",
@@ -623,7 +641,7 @@
     },
     "packages/mystmd": {
       "name": "mystmd",
-      "version": "1.8.2",
+      "version": "1.9.1",
       "bin": {
         "myst": "./dist/myst.cjs",
       },
@@ -645,7 +663,7 @@
     },
     "packages/tex-to-myst": {
       "name": "tex-to-myst",
-      "version": "1.0.45",
+      "version": "1.0.46",
       "dependencies": {
         "@unified-latex/unified-latex": "^1.2.2",
         "myst-common": "^1.9.4",
@@ -2039,6 +2057,8 @@
 
     "myst-to-html": ["myst-to-html@workspace:packages/myst-to-html"],
 
+    "myst-to-ipynb": ["myst-to-ipynb@workspace:packages/myst-to-ipynb"],
+
     "myst-to-jats": ["myst-to-jats@workspace:packages/myst-to-jats"],
 
     "myst-to-md": ["myst-to-md@workspace:packages/myst-to-md"],
@@ -2425,7 +2445,7 @@
 
     "tex-to-myst": ["tex-to-myst@workspace:packages/tex-to-myst"],
 
-    "tex-to-typst": ["tex-to-typst@0.0.18", "", { "dependencies": { "@unified-latex/unified-latex": "^1.4.0", "@unified-latex/unified-latex-util-arguments": "^1.4.0", "@unified-latex/unified-latex-util-parse": "^1.4.0" } }, "sha512-hFwpIW31t3YnkZJA+lemvt5rLSgFxRwMwOdod629HfYD/fM67ZNw/NPuV5a4AQhV1VPsr7UW8kZwPc7G7/ahkw=="],
+    "tex-to-typst": ["tex-to-typst@0.0.20", "", { "dependencies": { "@unified-latex/unified-latex": "^1.4.0", "@unified-latex/unified-latex-util-arguments": "^1.4.0", "@unified-latex/unified-latex-util-parse": "^1.4.0", "unified": "^10.1.2" } }, "sha512-q6cVBkEYAX+N8wgA5pmyw4I1URm12X0JDpBEEozo626G8MjJuOfsDeMwuLzodHJPuvsk/LRRtANxpqK8JwpiXQ=="],
 
     "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
 
@@ -2671,21 +2691,9 @@
 
     "@jupyterlab/services/@jupyterlab/nbformat": ["@jupyterlab/nbformat@4.4.8", "", { "dependencies": { "@lumino/coreutils": "^2.2.1" } }, "sha512-zhpmu4jkIGgjLRzClifnVmM1NKfrC+A7Gcz8hnXJBinJwf6nMZaQnnXo+J6G93e0epw0E/YBrJ1kI/JJWLMeCg=="],
 
-    "@jupyterlab/services/@lumino/coreutils": ["@lumino/coreutils@2.2.1", "", { "dependencies": { "@lumino/algorithm": "^2.0.3" } }, "sha512-yij4TnxDIum7xfFUsVvZB0oLv4shs2mNbn3juwtEIsruvVBPmurNzKX0Y8z2QetbP2AZ6MSFtBzEKsihf0H0VA=="],
-
     "@jupyterlab/settingregistry/@jupyterlab/nbformat": ["@jupyterlab/nbformat@4.4.8", "", { "dependencies": { "@lumino/coreutils": "^2.2.1" } }, "sha512-zhpmu4jkIGgjLRzClifnVmM1NKfrC+A7Gcz8hnXJBinJwf6nMZaQnnXo+J6G93e0epw0E/YBrJ1kI/JJWLMeCg=="],
 
-    "@jupyterlab/settingregistry/@lumino/coreutils": ["@lumino/coreutils@2.2.1", "", { "dependencies": { "@lumino/algorithm": "^2.0.3" } }, "sha512-yij4TnxDIum7xfFUsVvZB0oLv4shs2mNbn3juwtEIsruvVBPmurNzKX0Y8z2QetbP2AZ6MSFtBzEKsihf0H0VA=="],
-
     "@jupyterlab/settingregistry/json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
-
-    "@jupyterlab/statedb/@lumino/coreutils": ["@lumino/coreutils@2.2.1", "", { "dependencies": { "@lumino/algorithm": "^2.0.3" } }, "sha512-yij4TnxDIum7xfFUsVvZB0oLv4shs2mNbn3juwtEIsruvVBPmurNzKX0Y8z2QetbP2AZ6MSFtBzEKsihf0H0VA=="],
-
-    "@lumino/commands/@lumino/coreutils": ["@lumino/coreutils@2.2.1", "", { "dependencies": { "@lumino/algorithm": "^2.0.3" } }, "sha512-yij4TnxDIum7xfFUsVvZB0oLv4shs2mNbn3juwtEIsruvVBPmurNzKX0Y8z2QetbP2AZ6MSFtBzEKsihf0H0VA=="],
-
-    "@lumino/polling/@lumino/coreutils": ["@lumino/coreutils@2.2.1", "", { "dependencies": { "@lumino/algorithm": "^2.0.3" } }, "sha512-yij4TnxDIum7xfFUsVvZB0oLv4shs2mNbn3juwtEIsruvVBPmurNzKX0Y8z2QetbP2AZ6MSFtBzEKsihf0H0VA=="],
-
-    "@lumino/signaling/@lumino/coreutils": ["@lumino/coreutils@2.2.1", "", { "dependencies": { "@lumino/algorithm": "^2.0.3" } }, "sha512-yij4TnxDIum7xfFUsVvZB0oLv4shs2mNbn3juwtEIsruvVBPmurNzKX0Y8z2QetbP2AZ6MSFtBzEKsihf0H0VA=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -2711,8 +2719,6 @@
 
     "@unified-latex/unified-latex-util-to-string/prettier": ["prettier@2.8.8", "", { "bin": "bin-prettier.js" }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
-    "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
@@ -2726,8 +2732,6 @@
     "boxen/chalk": ["chalk@5.3.0", "", {}, "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="],
 
     "cacheable-request/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
-
-    "cffjs/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "check-node-version/chalk": ["chalk@3.0.0", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg=="],
 
@@ -2786,8 +2790,6 @@
     "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "eslint/cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
-
-    "eslint/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "eslint/glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -2891,8 +2893,6 @@
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
-    "meca/jats-xml": ["jats-xml@1.0.8", "", { "dependencies": { "adm-zip": "^0.5.10", "doi-utils": "^2.0.0", "fair-principles": "^2.0.0", "jats-fetch": "^1.0.8", "jats-tags": "^1.0.8", "jats-utils": "^1.0.8", "js-yaml": "^4.1.0", "node-fetch": "^3.3.1", "unist-util-is": "^5.2.1", "unist-util-remove": "^3.1.0", "unist-util-select": "^4.0.0", "which": "^3.0.1", "xml-js": "^1.6.11" }, "peerDependencies": { "chalk": "^5.2.0", "commander": "^10.0.1" }, "bin": { "jats": "dist/jats.cjs" } }, "sha512-yI1rbW/toz4x04/pDp1gsNcySxC4kFhJcU91sqBZdliCg5PXvCOCnb/OhGGPAD/vehBWGiGbdjuLbQ4WDcBSNA=="],
-
     "module-definition/ast-module-types": ["ast-module-types@3.0.0", "", {}, "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ=="],
 
     "module-definition/node-source-walk": ["node-source-walk@4.3.0", "", { "dependencies": { "@babel/parser": "^7.0.0" } }, "sha512-8Q1hXew6ETzqKRAs3jjLioSxNfT1cx74ooiF8RlAONwVMcfq+UdzLC2eB5qcPldUxaE5w3ytLkrmV1TGddhZTA=="],
@@ -2989,8 +2989,6 @@
 
     "tsutils/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
-    "vite/fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
-
     "vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "vitest/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -3051,15 +3049,11 @@
 
     "@typescript-eslint/utils/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
-    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
-    "cffjs/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "check-node-version/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -3073,8 +3067,6 @@
 
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "color/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
     "concurrently/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "concurrently/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -3084,8 +3076,6 @@
     "default-browser/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
     "default-browser/execa/human-signals": ["human-signals@4.3.1", "", {}, "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ=="],
-
-    "default-browser/execa/onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
 
     "default-browser/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -3271,8 +3261,6 @@
 
     "check-node-version/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
-    "check-node-version/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
-
     "cliui/wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "concurrently/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
@@ -3283,15 +3271,11 @@
 
     "default-browser/execa/cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "default-browser/execa/onetime/mimic-fn": ["mimic-fn@4.0.0", "", {}, "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="],
-
     "eslint-config-next/@typescript-eslint/parser/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@5.62.0", "", { "dependencies": { "@typescript-eslint/types": "5.62.0", "eslint-visitor-keys": "^3.3.0" } }, "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw=="],
 
     "eslint-config-next/@typescript-eslint/parser/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@5.62.0", "", { "dependencies": { "@typescript-eslint/types": "5.62.0", "eslint-visitor-keys": "^3.3.0" } }, "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw=="],
 
     "eslint/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
-
-    "eslint/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "eslint/cross-spawn/shebang-command/shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
@@ -3311,21 +3295,15 @@
 
     "log-symbols/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
-    "log-symbols/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
-
     "log-update/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "log-update/wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
 
     "madge/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
-    "madge/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
-
     "npm-run-all/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
     "ora/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
-
-    "ora/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "precinct/detective-typescript/@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@4.33.0", "", {}, "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ=="],
 
@@ -3345,38 +3323,16 @@
 
     "spawndamnit/cross-spawn/shebang-command/shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "wrap-ansi-cjs/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
-    "check-node-version/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "cliui/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "concurrently/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
     "default-browser/execa/cross-spawn/shebang-command/shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "eslint/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "inquirer/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
     "intersphinx/myst-cli-utils/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
-
-    "intersphinx/myst-cli-utils/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
-
-    "log-symbols/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "madge/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "ora/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "precinct/detective-typescript/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@2.1.0", "", {}, "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="],
 
     "run-applescript/execa/cross-spawn/shebang-command/shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
-
-    "intersphinx/myst-cli-utils/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
   }
 }

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -12,6 +12,7 @@ However, we offer support for two analytics tracking systems:
 2. [Plausible](https://plausible.io/), which is privacy-friendly alternative to Google.
 
 These are set using template specific options in your site configuration using either an `analytics_google` or an `analytics_plausible` key.
+See [](#site-options) for more on site options and how to set them.
 
 ## Google Analytics
 
@@ -23,6 +24,8 @@ site:
   options:
     analytics_google: UA-XXXXX # Measurement ID or Tracking ID
 ```
+
+![](#page-site-options-note)
 
 See [Google Analytics docs](https://developers.google.com/analytics/devguides/collection/gtagjs) for more information on how to find this Measurement ID.
 
@@ -36,6 +39,8 @@ site:
   options:
     analytics_plausible: mystmd.org # Domain(s) to track
 ```
+
+![](#page-site-options-note)
 
 See [Plausible docs](https://plausible.io/docs/plausible-script) for more information on how to find the domain. Note, you only copy in the contents of: `data-domain="COPY_THIS"`, which can be a comma-separated list for multiple domains.
 

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -69,6 +69,8 @@ site:
     numbered_references: true
 ```
 
+![](#page-site-options-note)
+
 ### Writing DOIs to BibTeX
 
 If you encounter problems fetching DOIs from `https://doi.org`, for example the downloaded citation does not include all the data you expect or requests to `https://doi.org` are failing on an automated continuous integration platform, you may write your DOI citations to file using the MyST command:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,6 +154,15 @@ The behavior of each frontmatter field is hard-coded within MyST. These are the 
 
 +++
 
+(multiple-projects-deprecated)=
+
+:::{warning} Multiple projects in one `myst.yml` site has been deprecated
+A MyST site maps one-to-one to a single project.
+
+Historically, the `site.projects` list could combine several projects under one site, each mounted at its own URL slug. This is deprecated due to development complexity, and we encourage composing multiple MyST sites at a higher level (e.g. DNS, file system or through custom web-applications).
+You can combine multiple projects by deploying multiple myst sites next to each other, for example, using GitHub pages or web-based routing. A worked example, which is used in the Jupyter Book documentation deployment can be [found here](https://jupyterbook.org/blog/posts/2026/multi-repo).
+:::
+
 (composing-myst-yml)=
 
 ## Compose and extend configuration `.yml` files

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,8 @@ See [](#field-behavior) below about how these two sources of settings interact.
 
 See also [](frontmatter.md) for a list of supported frontmatter settings.
 
+See [](#site-options) for theme settings like analytics, logos, and navigation toggles, which are set under `site.options` in your `myst.yml`.
+
 ## Page-level frontmatter
 
 ### In a MyST markdown file
@@ -153,6 +155,15 @@ The behavior of each frontmatter field is hard-coded within MyST. These are the 
 : the field is only available on projects, and not present on pages and it will be ignored if set there.
 
 +++
+
+(multiple-projects-deprecated)=
+
+:::{warning} Multiple projects in one `myst.yml` site has been deprecated
+A MyST site maps one-to-one to a single project.
+
+Historically, the `site.projects` list could combine several projects under one site, each mounted at its own URL slug. This is deprecated due to development complexity, and we encourage composing multiple MyST sites at a higher level (e.g. DNS, file system or through custom web-applications).
+You can combine multiple projects by deploying multiple myst sites next to each other, for example, using GitHub pages or web-based routing. A worked example, which is used in the Jupyter Book documentation deployment can be [found here](https://jupyterbook.org/blog/posts/2026/multi-repo).
+:::
 
 (composing-myst-yml)=
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,8 @@ See [](#field-behavior) below about how these two sources of settings interact.
 
 See also [](frontmatter.md) for a list of supported frontmatter settings.
 
+See [](#site-options) for theme settings like analytics, logos, and navigation toggles, which are set under `site.options` in your `myst.yml`.
+
 ## Page-level frontmatter
 
 ### In a MyST markdown file

--- a/docs/creating-pdf-documents.md
+++ b/docs/creating-pdf-documents.md
@@ -99,6 +99,76 @@ Ensure that you download a full distribution with appropriate libraries installe
 
 (rendering-pdfs-with-typst)=
 
+### LaTeX export gotchas
+
+By default, MyST-rendered PDFs will use the `\section` command as the top-level heading in LaTeX. This is standard for scientific papers and short reports. However, if you are writing a book or long document (e.g. with Jupyter Book), this may cause errors as LaTeX expects the `\chapter` or `\part` command to be top-level. MyST can accomodate for this difference by manually setting the `level` key to each file you wish to export, as per the table below:
+
+| Level | Corresponding LaTeX command |
+| ----- | --------------------------- |
+| -1    | `\part`                     |
+| 0     | `\chapter`                  |
+| 1     | `\section`                  |
+| 2     | `\subsection`               |
+| 3     | `\subsubsection`            |
+
+For instance, assuming you had the following directory structure:
+
+```
+.
+├── chapter-one
+│  ├── index.md
+│  ├── section-one.md
+│  └── section-two.md
+├── chapter-two
+│  ├── index.md
+│  ├── section-one.md
+│  └── section-two.md
+├── index.md
+└── myst.yml
+```
+
+And the following table of contents in your `myst.yml`:
+
+```yml
+toc:
+  - file: index.md
+  - file: chapter-one/index.md
+    children:
+      - file: chapter-one/section-one.md
+      - file: chapter-one/section-two.md
+  - file: chapter-two/index.md
+    children:
+      - file: chapter-two/section-one.md
+      - file: chapter-two/section-two.md
+# ... rest of your config
+```
+
+By default, MyST will assign `chapter-one/index.md` with the `\section` command in LaTeX, instead of the `\chapter` command. To be able to change this behavior, you will need to set the `level` key for every page, as follows:
+
+```yml
+exports:
+  - format: pdf
+    template: plain_latex_book
+    output: my_book.pdf
+    articles:
+      - file: index.md
+        level: 0
+      - file: chapter-one/index.md
+        level: 0
+      - file: chapter-one/section-one.md
+        level: 1
+      - file: chapter-one/section-two.md
+        level: 1
+      - file: chapter-two/index.md
+        level: 0
+      - file: chapter-two/section-one.md
+        level: 1
+      - file: chapter-two/section-two.md
+        level: 1
+```
+
+This will render the chapters using the `\chapter` command, ensuring it is consistent with LaTeX's book rendering.
+
 ## Rendering PDFs with Typst
 
 [Typst](https://typst.app) is a markup-based typesetting language. It is **significantly faster and simpler than using $\LaTeX$** with results of equal or better quality.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -56,23 +56,11 @@ which will serve a static version of the site.
 :::{danger} Static sites should have an `index.html`
 :class: dropdown
 
-Your site should be configured with a single project at the root, this can be done by removing the `site.projects` list so that the site builds at the root url, rather than in a nested folder.
+A static site needs an `index.html` at its root.
+MyST generates one automatically when your site has a single project built at the root URL, which is the default.
 
-If your project is configured to be in a nested folder using a project `slug`, a site index will _not_ be created and your project will be instead accessible at a nested slug.
-
-To fix this, change your `site` configuration to use a flat rather than nested project:
-
-```yaml
-version: 1
-# Your project must be listed in the same myst.yml configuration
-project: ...
-site:
-  title: Site Title
-  # Delete the following `site.projects` configuration:
-  # projects:
-  #   - slug: nested-folder
-  #     path: .
-```
+If a root `index.html` is _not_ generated, your project is being built under a nested URL instead of at the root.
+You're probably using the [deprecated `projects:` configuration](#multiple-projects-deprecated), and should remove it.
 
 :::
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -398,6 +398,8 @@ No content or theme server is required for a static site build. Steps are:
 
 We'll use the mystmd docs site as an example.
 
+Under the hood, `mystmd build --html` starts myst-theme as a local Remix server, fetches each route as HTML, writes the results to disk, and runs a small post-processing pass (see [`packages/myst-cli/src/build/html/index.ts`](https://github.com/jupyter-book/mystmd/blob/main/packages/myst-cli/src/build/html/index.ts)).
+
 #### Build theme
 
 To build a static site against a local theme, the theme must be built as it would be for production. For that we will use the "make" target

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -562,7 +562,9 @@ When you publish a release, you upload a new version of the tool for package man
 
 - **Find the changesets PR**. This contains a list of the version updates that will be included with this release. [Here's an example of a release PR](https://github.com/jupyter-book/mystmd/pull/1896).
 - Review the changeset PR.
-  - Ensure that `mystmd` is in the changesets. Or you are intentionally **not** releasing `mystmd` (this generally shouldn't happen), in which case the python and release notes are expected to fail.
+  - Ensure that either `mystmd` or `myst-cli` is in the changesets.
+    Or, ensure you are intentionally **not** releasing `mystmd` (this generally shouldn't happen), in which case the python and release notes are expected to fail.
+    See [](#changesets:myst-cli) for more explanation.
   - Ensure that private or non-existent packages like docs, etc. are not in the changesets (these will cause an early failure)
   - Ensure that there are no **new** myst packages that need to be published (see [](#release:new-package))
 - **Merge the changesets PR**. After merging that PR, [this GitHub action will make a release](https://github.com/jupyter-book/mystmd/blob/main/.github/workflows/release.yml).
@@ -756,6 +758,20 @@ For now, we try to abide by the following rules for version bumps:
 - **major**: Backward incompatible change to the underlying supported MyST data. These would be cases where a non-developer MyST user's project or site built with major version _N_ would not work with major version _N+1_. Currently, we never intentionally make these changes.
 - **minor**: Backward incompatible change to the JavaScript API, for example, changing the call signature or deleting an exported function. These can be a headache for developers consuming MyST libraries, but they do not break MyST content.
 - **patch**: For now, everything else is a patch: bug fixes, new features, refactors. This means some patch releases have a huge, positive impact on users and other patch releases are basically invisible.
+
+(changesets:myst-cli)=
+#### What if changesets doesn't bump `mystmd` or `myst-cli`?
+
+The auto-generated changesets release PR must list at least one changeset that bumps `mystmd` or `myst-cli`, or its CI will fail.
+This is because we *almost always* want to release a new `mystmd` on merge, which only happens if one of these is bumped.
+
+If you merge the changesets PR when neither is bumped, the release job of `mystmd-py` to PyPI will fail, and a GitHub release won't be made for the repository.
+The packages that we _did update_ will still be uploaded to NPM.
+Here's an example of this happening: [mystmd#2857](https://github.com/jupyter-book/mystmd/issues/2857).
+
+**You can still merge the Changesets PR if you want!**
+If you intentionally don't want a `mystmd` bump on this release, override the failing check and merge the release PR anyway.
+NPM still publishes everything else, and the PyPI and GitHub release jobs are an expected failure with nothing to fix afterwards.
 
 ## Packages in the mystmd repository
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -398,6 +398,8 @@ No content or theme server is required for a static site build. Steps are:
 
 We'll use the mystmd docs site as an example.
 
+Under the hood, `mystmd build --html` starts myst-theme as a local Remix server, fetches each route as HTML, writes the results to disk, and runs a small post-processing pass (see [`packages/myst-cli/src/build/html/index.ts`](https://github.com/jupyter-book/mystmd/blob/main/packages/myst-cli/src/build/html/index.ts)).
+
 #### Build theme
 
 To build a static site against a local theme, the theme must be built as it would be for production. For that we will use the "make" target
@@ -560,7 +562,9 @@ When you publish a release, you upload a new version of the tool for package man
 
 - **Find the changesets PR**. This contains a list of the version updates that will be included with this release. [Here's an example of a release PR](https://github.com/jupyter-book/mystmd/pull/1896).
 - Review the changeset PR.
-  - Ensure that `mystmd` is in the changesets. Or you are intentionally **not** releasing `mystmd` (this generally shouldn't happen), in which case the python and release notes are expected to fail.
+  - Ensure that either `mystmd` or `myst-cli` is in the changesets.
+    Or, ensure you are intentionally **not** releasing `mystmd` (this generally shouldn't happen), in which case the python and release notes are expected to fail.
+    See [](#changesets:myst-cli) for more explanation.
   - Ensure that private or non-existent packages like docs, etc. are not in the changesets (these will cause an early failure)
   - Ensure that there are no **new** myst packages that need to be published (see [](#release:new-package))
 - **Merge the changesets PR**. After merging that PR, [this GitHub action will make a release](https://github.com/jupyter-book/mystmd/blob/main/.github/workflows/release.yml).
@@ -754,6 +758,20 @@ For now, we try to abide by the following rules for version bumps:
 - **major**: Backward incompatible change to the underlying supported MyST data. These would be cases where a non-developer MyST user's project or site built with major version _N_ would not work with major version _N+1_. Currently, we never intentionally make these changes.
 - **minor**: Backward incompatible change to the JavaScript API, for example, changing the call signature or deleting an exported function. These can be a headache for developers consuming MyST libraries, but they do not break MyST content.
 - **patch**: For now, everything else is a patch: bug fixes, new features, refactors. This means some patch releases have a huge, positive impact on users and other patch releases are basically invisible.
+
+(changesets:myst-cli)=
+#### What if changesets doesn't bump `mystmd` or `myst-cli`?
+
+The auto-generated changesets release PR must list at least one changeset that bumps `mystmd` or `myst-cli`, or its CI will fail.
+This is because we *almost always* want to release a new `mystmd` on merge, which only happens if one of these is bumped.
+
+If you merge the changesets PR when neither is bumped, the release job of `mystmd-py` to PyPI will fail, and a GitHub release won't be made for the repository.
+The packages that we _did update_ will still be uploaded to NPM.
+Here's an example of this happening: [mystmd#2857](https://github.com/jupyter-book/mystmd/issues/2857).
+
+**You can still merge the Changesets PR if you want!**
+If you intentionally don't want a `mystmd` bump on this release, override the failing check and merge the release PR anyway.
+NPM still publishes everything else, and the PyPI and GitHub release jobs are an expected failure with nothing to fix afterwards.
 
 ## Packages in the mystmd repository
 

--- a/docs/figures.md
+++ b/docs/figures.md
@@ -183,7 +183,7 @@ For animated images, `.gif`, the first frame is extracted for static exports.
 :class: dropdown
 The image transforms and optimizations requires you to have the following packages installed:
 
-- [imagemagik](https://imagemagick.org/) for conversion between raster formats
+- [ImageMagick](https://imagemagick.org/) for conversion between raster formats
 - [inkscape](https://inkscape.org/) for conversion between some vector formats
 - [webp](https://developers.google.com/speed/webp) for image optimizations
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -97,11 +97,15 @@ mamba 1.5.8
 conda 24.7.1
 ```
 
-🛠 Install `texlive-core` and `latexmk` from `conda-forge`:
+🛠 Install `texlive-core`, `latexmk`, and `imagemagick` from `conda-forge`:
 
 ```shell
-$ mamba install -c conda-forge texlive-core latexmk
+$ mamba install -c conda-forge texlive-core latexmk imagemagick
 ```
+
+`imagemagick` is optional, but recommended if your documents include images that need conversion for PDF output.
+
+For Debian or Ubuntu based systems, the equivalent packages commonly include `texlive-xetex`, `texlive-fonts-recommended`, `texlive-plain-generic`, `latexmk`, and `imagemagick`.
 
 ::::
 :::::

--- a/docs/quickstart-static-exports.md
+++ b/docs/quickstart-static-exports.md
@@ -99,7 +99,14 @@ See [](./creating-word-documents.md) to learn about exporting to `*.docx`, for e
 
 ## Export to PDF with Latex
 
-To export to PDF with $\LaTeX$, first ensure it is installed, see [](./creating-pdf-documents.md) for more information.
+Before building PDF exports locally, make sure your environment has the external tools that MyST calls
+during the export:
+
+- **$\LaTeX$**: install a full $\LaTeX$ distribution before using the default PDF renderer. See
+  [](#install-latex) for setup guidance.
+- **ImageMagick**: install [ImageMagick](https://imagemagick.org/) if your document includes images
+  that need conversion for PDF output, such as animated GIFs or rasterized fallbacks for unsupported
+  formats. See [](./figures.md) for more on image format handling.
 
 First, we need to decide which template to export to, for this, we will use the `myst templates` command, and for example list all the two-column, PDF templates available.
 

--- a/docs/website-downloads.md
+++ b/docs/website-downloads.md
@@ -4,21 +4,22 @@ short_title: Downloads & Static Files
 description: Add download links to your website on each page or project
 ---
 
-You can bundle files with your MyST site for others to download and re-use.
-There are two ways to specify downloads with a MyST site.
+MyST provides three independent mechanisms for bundling files with your site:
 
-:::{note} Download URLs will changed based on the file content
-MyST will generate a _hashed filename_ for any files bundled with your site.
-For example: `myfile.[HASH].png`.
-This means download URLs will not be persistent if the content changes.
+- **`project.static_files`** — copies files or folders into the build output at a stable, predictable URL, without hashing and without rendering any link.
+  Use this for files that must live at a known location (e.g. a `CNAME` file for a custom domain).
+  See [the static files section](#downloads:static-files).
+- **`{download}` role** — an inline role used directly in content to create a download link at the point of use.
+  MyST content-hashes the filename (e.g. `myfile.[HASH].png`) so downstream caches invalidate when the file changes.
+  See [the `{download}` role section](#download-role).
+- **`downloads:` frontmatter** — page or project configuration that populates the page's download panel in the site UI (not inline in content).
+  Can reference local files, export IDs, or remote URLs.
+  See [the `downloads:` frontmatter section](#download-link).
 
-See this issue tracking how to make these URLs stable: https://github.com/jupyter-book/mystmd/issues/1196
-:::
+(download-role)=
+## Inline download links with the `{download}` role
 
-## Use the `{download}` role
-
-The {myst:role}`download` role takes a path to a file, and generates a download link from it.
-Such a role may be defined at the project or the page level.
+The {myst:role}`download` role takes a path to a file and generates an inline download link at that point in the content.
 
 For example:
 
@@ -31,8 +32,48 @@ For example:
 {download}`references.bib`
 ::::
 
+(downloads:static-files)=
+## Include static files with stable links
+
+Use the `project.static_files` option to copy files or folders into your build output.
+This is useful when a file needs to keep a predictable name at a known location.
+
+To do so, add a list of paths under `project:` in your `myst.yml`:
+
+```{code-block} yaml
+:filename: myst.yml
+
+project:
+  static_files:
+    - path/to/CNAME # A file name, for example
+    - path/to/assets # A folder name, for example
+```
+
+Each entry is copied into the **root** of the build output (`_build/html/`).
+The behavior changes slightly based on whether you link to a file or a folder:
+
+- A **file** path (e.g. `path/to/CNAME`) is copied to the root using only its filename.
+  Parent directories are **not** preserved, so the file ends up at `_build/html/CNAME`.
+- A **folder** path (e.g. `path/to/assets`) is copied recursively using only the folder's name.
+  As with files, parent directories are **not** preserved, but sub-folder contents are preserved.
+  The folder and its contents end up at `_build/html/assets/...`.
+
+:::{note} Linking to static files from Markdown
+Static files are accessible by URL in the final build (e.g. `/CNAME`, `/assets/...`), but MyST does not resolve them as content pages.
+Markdown links such as `[text](path/to/CNAME)` will produce a "file not found" warning during the build.
+To suppress the warning, use an explicit URL path in your link (e.g. `[text](/CNAME)`), or use the {myst:role}`download` role to attach the file as a download link instead.
+:::
+
+:::{note} Want cache busting or a rendered inline link?
+If you'd rather have MyST render the link inline and hash the filename for cache busting, use the {myst:role}`download` role instead.
+If you want the file to appear in the page's download panel rather than inline in content, use the [`downloads:` frontmatter](#download-link) instead.
+:::
+
 (download-link)=
-## Use project or page configuration
+## Download panel with `downloads:` frontmatter
+
+The `downloads:` key in page or project frontmatter populates the **download panel** shown in the site UI (typically in the page toolbar).
+It is unrelated to the `{download}` role: `downloads:` configures a UI element, not inline content links.
 
 There are some special configuration fields to specify files that should be bundled for download with your site. These are:
 
@@ -74,6 +115,34 @@ project:
 ```
 
 :::
+
+
+(multiple-downloads)=
+### Example: Define multiple downloads at once
+
+The following example has several downloads: the source file, as above, an exported pdf, a remote file, and a link to another website.
+In addition, when you specify `downloads:`, it will over-ride the default download behavior (which is to link to the source file of the current page).
+This example manually includes a download to the source file to re-enable this.
+
+```{code-block} yaml
+:filename: index.md
+---
+exports:
+  - output: paper.pdf
+    template: lapreprint-typst
+    id: my-paper
+downloads:
+  - file: index.md
+    title: Source File
+  - id: my-paper
+    title: Publication
+  - url: https://example.com/files/script.py
+    filename: script.py
+    title: Sample Code
+  - url: https://example.com/more-info
+    title: More Info
+---
+```
 
 
 (include-exported-pdf)=
@@ -179,32 +248,5 @@ downloads:
     title: Source File
 ```
 
-(multiple-downloads)=
-
-## Include several downloads at once
-
-The following example has several downloads: the source file, as above, an exported pdf, a remote file, and a link to another website.
-In addition, when you specify `downloads:`, it will over-ride the default download behavior (which is to link to the source file of the current page).
-This example manually includes a download to the source file to re-enable this.
-
-```{code-block} yaml
-:filename: index.md
----
-exports:
-  - output: paper.pdf
-    template: lapreprint-typst
-    id: my-paper
-downloads:
-  - file: index.md
-    title: Source File
-  - id: my-paper
-    title: Publication
-  - url: https://example.com/files/script.py
-    filename: script.py
-    title: Sample Code
-  - url: https://example.com/more-info
-    title: More Info
----
-```
 
 [typst-gha]: https://github.com/marketplace/actions/setup-typst

--- a/docs/website-navigation.md
+++ b/docs/website-navigation.md
@@ -136,6 +136,8 @@ site:
     hide_toc: true
 ```
 
+![](#page-site-options-note)
+
 ### Edit the primary sidebar footer
 
 The "Made with MyST" branding at the bottom of the primary sidebar can be customized by providing a markdown file, e.g. `primary-sidebar-footer.md`, and adding the path to the `site.parts.toc_footer` configuration to your `myst.yml`:
@@ -191,6 +193,8 @@ site:
   options:
     hide_outline: true
 ```
+
+![](#page-site-options-note)
 
 ### Make content expand to the right margin
 

--- a/docs/website-style.md
+++ b/docs/website-style.md
@@ -25,6 +25,8 @@ site:
     style: ./my-style.css
 ```
 
+![](#page-site-options-note)
+
 For example, the style-sheet could contain styling for `em` elements nested below a particular `text-gradient` class:
 
 :::{literalinclude} public/style.css

--- a/docs/website-templates.md
+++ b/docs/website-templates.md
@@ -118,10 +118,14 @@ getting-started/
 If both `getting-started.md` and `getting-started/index.md` exist, the sibling file takes the slug `getting-started` first, and the folder's index file gets a deduplicated slug like `getting-started-1`.
 :::
 
+(site-options-page)=
+
 ### Page Options
 
 Any option from `site.options` can be overridden per-page in the frontmatter under the `site` key.
-Note that the nesting is different: options are placed directly under `site:` in page frontmatter, not under `site.options:`.
+
+(page-site-options-note)=
+When setting an option from a page, omit the `options:` key - put it directly under `site:`, not `site.options:`. See [](#site-options-page).
 
 ```{code-block} yaml
 :filename: my-page.md

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:format": "turbo run lint:format",
     "lint:circular": "madge -c packages/*/src/*",
     "test": "turbo run test",
-    "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "format": "prettier --write \"**/*.{ts,tsx,md}\" --ignore-pattern 'worktrees'",
     "changeset": "changeset",
     "version": "changeset version && bun install",
     "publish": "bun run clean && bun run build -- --force && changeset publish && git push --follow-tags",
@@ -42,7 +42,7 @@
   },
   "packageManager": "bun@1.3.10",
   "lint-staged": {
-    "*.ts": "eslint --config ./.eslintrc.cjs --fix",
+    "*.ts": "eslint --config ./.eslintrc.cjs --ignore-pattern 'worktrees' --fix",
     "*.{js,jsx,ts,tsx,md,html,css,json}": "prettier --write"
   }
 }

--- a/packages/jtex/docs/template-yml.md
+++ b/packages/jtex/docs/template-yml.md
@@ -70,9 +70,10 @@ id (string, required)
 : The preferred form of IDs is `snake_case` identifiers.
 
 type:
-: One of `boolean`, `string`, `choice`, `frontmatter`
-: If the type is `frontmatter` then the ID must be included in\
-`title`, `description`, `authors`, `short_title`, or `keywords`
+: One of `boolean`, `string`, `number`, `choice`, or `file`.
+: Use `options` for values that are specific to your template. Use [`doc`](#template-doc)
+  for standard MyST frontmatter fields such as `title`, `description`, `authors`,
+  `short_title`, or `keywords`.
 
 title (string, optional)
 : The title of the property to show in user interfaces
@@ -98,7 +99,9 @@ default
 
 ## Template Document
 
-The template `doc` lists the [frontmatter](../../../docs/frontmatter.md) options that are required for or used by the template. These can have a `required` field (boolean) as well as an optional `description`.
+The template `doc` lists the [frontmatter](https://mystmd.org/guide/frontmatter) fields that are required for or used by the template. These can have a `required` field (boolean) as well as an optional `description`.
+
+Add fields to `doc` when the template needs normal document metadata. Those values come from the page or project frontmatter and are available in `template.tex` on the `doc` object. For example, a template that renders the article title and keywords can declare:
 
 ```yaml
 doc:
@@ -109,6 +112,20 @@ doc:
       Include from three to ten pertinent keywords specific to the article; yet
       reasonably common within the subject discipline.
 ```
+
+Then use the fields from `doc` in the template:
+
+```latex
+[# if doc.title #]
+\title{[- doc.title -]}
+[# endif #]
+
+[# if doc.keywords #]
+\keywords{[- doc.keywords | join(', ') -]}
+[# endif #]
+```
+
+Use `options` instead when you need a template-specific setting that is not part of MyST frontmatter, such as paper size, anonymous review mode, or a journal-specific formatting choice.
 
 (template-parts)=
 

--- a/packages/markdown-it-myst/src/citations.ts
+++ b/packages/markdown-it-myst/src/citations.ts
@@ -31,9 +31,9 @@ type InlineState = {
 
 export const citationsPlugin: PluginWithOptions = (md) => {
   const regexes = {
-    citation: /^([^^-]|[^^].+?)?(-)?@([\w][\w:.#$%&\-+?<>~/]*)(.+)?$/,
+    citation: /^([^^-]|[^^].+?)?(-)?@([\w][\w:.#$%&\-+?~/]*)(.+)?$/,
     // Only allow a short [suffix] for in text citations (e.g. 50 characters)
-    inText: /^@((?:[\w|{][\w:.#$%&\-+?<>~/]*[\w|}])|\w)(\s*)(\[([^\]]{1,50})\])?/,
+    inText: /^@((?:[\w|{][\w:.#$%&\-+?~/]*[\w|}])|\w)(\s*)(\[([^\]]{1,50})\])?/,
     allowedBefore: /^[^a-zA-Z0-9]$/,
   };
 

--- a/packages/markdown-it-myst/tests/cases.spec.ts
+++ b/packages/markdown-it-myst/tests/cases.spec.ts
@@ -45,7 +45,7 @@ casesList.forEach(({ title, cases, plugins }) => {
     test.each(casesToUse.map((c): [string, TestCase] => [c.title, c]))(
       '%s',
       (_, { md, tokens }) => {
-        const mdit = MarkdownIt();
+        const mdit = MarkdownIt({ html: true });
         plugins.forEach((p) => {
           mdit.use(PLUGINS[p]);
         });

--- a/packages/markdown-it-myst/tests/citations.yml
+++ b/packages/markdown-it-myst/tests/citations.yml
@@ -291,6 +291,58 @@ cases:
           - type: text
             content: 'letters@nospace'
       - type: paragraph_close
+  # Citation label stops at `<` so an autolink can follow immediately.
+  - title: Citation followed by autolink stops at `<`
+    md: '@scipy2025<https://mystmd.org>'
+    tokens:
+      - type: paragraph_open
+      - type: inline
+        children:
+          - type: cite
+            content: '@scipy2025'
+            col: [0, 10]
+            meta:
+              label: scipy2025
+              kind: narrative
+          - type: link_open
+          - type: text
+            content: 'https://mystmd.org'
+          - type: link_close
+      - type: paragraph_close
+  # Citation inside HTML span is parsed, but HTML tags are preserved as html_inline nodes.
+  - title: Citation inside HTML span does not eat HTML
+    md: '<b>before</b> <span class="mention">@asdf</span> <i>after</i>'
+    tokens:
+      - type: paragraph_open
+      - type: inline
+        children:
+          - type: html_inline
+            content: '<b>'
+          - type: text
+            content: 'before'
+          - type: html_inline
+            content: '</b>'
+          - type: text
+            content: ' '
+          - type: html_inline
+            content: '<span class="mention">'
+          - type: cite
+            content: '@asdf'
+            col: [36, 41]
+            meta:
+              label: asdf
+              kind: narrative
+          - type: html_inline
+            content: '</span>'
+          - type: text
+            content: ' '
+          - type: html_inline
+            content: '<i>'
+          - type: text
+            content: 'after'
+          - type: html_inline
+            content: '</i>'
+      - type: paragraph_close
   - title: Nested labels
     md: 'These include experimentally produced alkaline magmas from @iacovino2016 [`alkaline.xlsx`], basaltic melt inclusions from Kilauea [@tucker2019] and Gakkel Ridge [@bennett2019 `basalts.xlsx`].'
     tokens:

--- a/packages/myst-cli/src/build/html/index.ts
+++ b/packages/myst-cli/src/build/html/index.ts
@@ -24,6 +24,18 @@ import type { LocalProjectPage } from '../../project/types.js';
 
 const limitConnections = pLimit(5);
 
+/**
+ * Return true if any project in the current site has thebe configured.
+ * `project: jupyter: ...` aliases to `project: thebe`.
+ */
+function siteUsesThebe(session: ISession): boolean {
+  const state = session.store.getState();
+  const siteConfig = selectors.selectCurrentSiteConfig(state);
+  return (siteConfig?.projects ?? []).some(
+    (proj) => !!proj.path && !!selectors.selectLocalProjectConfig(state, proj.path)?.thebe,
+  );
+}
+
 export async function currentSiteRoutes(
   session: ISession,
   host: string,
@@ -199,9 +211,16 @@ export async function buildHtml(session: ISession, opts: StartOptions) {
   );
   await appServer.stop();
 
-  // Copy the files for the template used
+  // Copy files for the template used.
+
+  // Skip thebe JS chunks unless they are required.
   const templateBuildDir = path.join(template.templatePath, 'public');
-  fs.copySync(templateBuildDir, htmlDir);
+  const hasThebe = siteUsesThebe(session);
+  fs.copySync(templateBuildDir, htmlDir, {
+    filter: (src) =>
+      hasThebe ||
+      !path.basename(src).match(/^(\d+\.)?(thebe-(core|lite)(\.min)?\.js|thebe-core.*\.css)$/),
+  });
 
   // Copy all of the static assets
   fs.copySync(session.publicPath(), path.join(htmlDir, 'build'));

--- a/packages/myst-cli/src/build/html/index.ts
+++ b/packages/myst-cli/src/build/html/index.ts
@@ -1,3 +1,13 @@
+// Static-build HTML pipeline for MyST sites.
+//
+// The myst-theme (a separate repo) is the React/Remix app that renders MyST documents.
+// For a static build we spin myst-theme up as a local Remix server, fetch every route as fully-rendered HTML, and write the results to disk.
+// This file does that in `buildHtml`, plus a small post-processing pass (`rewriteAssetsFolder`) that:
+// - rewrites asset URLs
+// - injects an `/foo/index.html` -> `/foo/` redirect script
+//
+// The JS and CSS are produced by myst-theme.
+
 import fs from 'fs-extra';
 import path from 'node:path';
 import { writeFileToFolder } from 'myst-cli-utils';
@@ -72,10 +82,11 @@ export async function currentSiteRoutes(
 // This is defined in the remix `publicPath` and allows us to overwrite it here.
 const ASSETS_FOLDER = 'myst_assets_folder';
 
-// Script injected into every index.html to redirect "/foo/index.html" → "/foo/"
-// before Remix hydrates, preventing a URL mismatch that breaks client-side routing.
-// Remix renders the root index for URL "/" but static servers also serve the same
-// file at "/index.html", where the URL doesn't match any Remix route → runtime error.
+// Script injected at the end of <head> in every index.html to redirect
+// "/foo/index.html" → "/foo/" before Remix hydrates, preventing a URL
+// mismatch that breaks client-side routing. Remix renders the root index
+// for URL "/" but static servers also serve the same file at "/index.html",
+// where the URL doesn't match any Remix route → runtime error.
 const INDEX_REDIRECT_SCRIPT =
   `<script>(function(){` +
   `var p=window.location.pathname;` +
@@ -85,8 +96,9 @@ const INDEX_REDIRECT_SCRIPT =
 
 /**
  * Rewrite URLs in HTML/JS/JSON files pointing to the default assets folder in
- * terms of the provided base URL, and inject a URL-normalisation script into
- * every index.html so that direct access via /foo/index.html redirects to /foo/.
+ * terms of the provided base URL, and append a URL-normalisation script to
+ * the end of <head> in every index.html so that direct access via
+ * /foo/index.html redirects to /foo/.
  *
  * @param directory directory of files to recursively rewrite
  * @param baseurl base URL of the built site
@@ -106,7 +118,7 @@ function rewriteAssetsFolder(directory: string, baseurl?: string): void {
     let data = fs.readFileSync(file).toString();
     data = data.replace(new RegExp(`\\/${ASSETS_FOLDER}\\/`, 'g'), `${baseurl || ''}/build/`);
     if (filename === 'index.html') {
-      data = data.replace('<head>', `<head>${INDEX_REDIRECT_SCRIPT}`);
+      data = data.replace('</head>', `${INDEX_REDIRECT_SCRIPT}</head>`);
     }
     fs.writeFileSync(file, data);
   });

--- a/packages/myst-cli/src/build/html/index.ts
+++ b/packages/myst-cli/src/build/html/index.ts
@@ -20,6 +20,7 @@ import { slugToUrl } from 'myst-common';
 import pLimit from 'p-limit';
 import { fetchWithRetry } from '../../utils/fetchWithRetry.js';
 import { selectors } from '../../store/index.js';
+import { copyStaticFiles } from '../../utils/copyStaticFiles.js';
 import type { LocalProjectPage } from '../../project/types.js';
 
 const limitConnections = pLimit(5);
@@ -224,6 +225,14 @@ export async function buildHtml(session: ISession, opts: StartOptions) {
 
   // Copy all of the static assets
   fs.copySync(session.publicPath(), path.join(htmlDir, 'build'));
+
+  // Copy user static files to html build root
+  const siteConfig = selectors.selectCurrentSiteConfig(session.store.getState());
+  for (const proj of siteConfig?.projects ?? []) {
+    if (!proj.path) continue;
+    const projectConfig = selectors.selectLocalProjectConfig(session.store.getState(), proj.path);
+    copyStaticFiles(session, projectConfig?.static_files ?? [], htmlDir, proj.path);
+  }
   fs.copySync(path.join(session.sitePath(), 'config.json'), path.join(htmlDir, 'config.json'));
   fs.copySync(path.join(session.sitePath(), 'objects.inv'), path.join(htmlDir, 'objects.inv'));
 

--- a/packages/myst-cli/src/build/html/index.ts
+++ b/packages/myst-cli/src/build/html/index.ts
@@ -1,3 +1,13 @@
+// Static-build HTML pipeline for MyST sites.
+//
+// The myst-theme (a separate repo) is the React/Remix app that renders MyST documents.
+// For a static build we spin myst-theme up as a local Remix server, fetch every route as fully-rendered HTML, and write the results to disk.
+// This file does that in `buildHtml`, plus a small post-processing pass (`rewriteAssetsFolder`) that:
+// - rewrites asset URLs
+// - injects an `/foo/index.html` -> `/foo/` redirect script
+//
+// The JS and CSS are produced by myst-theme.
+
 import fs from 'fs-extra';
 import path from 'node:path';
 import { writeFileToFolder } from 'myst-cli-utils';
@@ -10,9 +20,22 @@ import { slugToUrl } from 'myst-common';
 import pLimit from 'p-limit';
 import { fetchWithRetry } from '../../utils/fetchWithRetry.js';
 import { selectors } from '../../store/index.js';
+import { copyStaticFiles } from '../../utils/copyStaticFiles.js';
 import type { LocalProjectPage } from '../../project/types.js';
 
 const limitConnections = pLimit(5);
+
+/**
+ * Return true if any project in the current site has thebe configured.
+ * `project: jupyter: ...` aliases to `project: thebe`.
+ */
+function siteUsesThebe(session: ISession): boolean {
+  const state = session.store.getState();
+  const siteConfig = selectors.selectCurrentSiteConfig(state);
+  return (siteConfig?.projects ?? []).some(
+    (proj) => !!proj.path && !!selectors.selectLocalProjectConfig(state, proj.path)?.thebe,
+  );
+}
 
 export async function currentSiteRoutes(
   session: ISession,
@@ -72,10 +95,11 @@ export async function currentSiteRoutes(
 // This is defined in the remix `publicPath` and allows us to overwrite it here.
 const ASSETS_FOLDER = 'myst_assets_folder';
 
-// Script injected into every index.html to redirect "/foo/index.html" → "/foo/"
-// before Remix hydrates, preventing a URL mismatch that breaks client-side routing.
-// Remix renders the root index for URL "/" but static servers also serve the same
-// file at "/index.html", where the URL doesn't match any Remix route → runtime error.
+// Script injected at the end of <head> in every index.html to redirect
+// "/foo/index.html" → "/foo/" before Remix hydrates, preventing a URL
+// mismatch that breaks client-side routing. Remix renders the root index
+// for URL "/" but static servers also serve the same file at "/index.html",
+// where the URL doesn't match any Remix route → runtime error.
 const INDEX_REDIRECT_SCRIPT =
   `<script>(function(){` +
   `var p=window.location.pathname;` +
@@ -85,8 +109,9 @@ const INDEX_REDIRECT_SCRIPT =
 
 /**
  * Rewrite URLs in HTML/JS/JSON files pointing to the default assets folder in
- * terms of the provided base URL, and inject a URL-normalisation script into
- * every index.html so that direct access via /foo/index.html redirects to /foo/.
+ * terms of the provided base URL, and append a URL-normalisation script to
+ * the end of <head> in every index.html so that direct access via
+ * /foo/index.html redirects to /foo/.
  *
  * @param directory directory of files to recursively rewrite
  * @param baseurl base URL of the built site
@@ -106,7 +131,7 @@ function rewriteAssetsFolder(directory: string, baseurl?: string): void {
     let data = fs.readFileSync(file).toString();
     data = data.replace(new RegExp(`\\/${ASSETS_FOLDER}\\/`, 'g'), `${baseurl || ''}/build/`);
     if (filename === 'index.html') {
-      data = data.replace('<head>', `<head>${INDEX_REDIRECT_SCRIPT}`);
+      data = data.replace('</head>', `${INDEX_REDIRECT_SCRIPT}</head>`);
     }
     fs.writeFileSync(file, data);
   });
@@ -187,12 +212,27 @@ export async function buildHtml(session: ISession, opts: StartOptions) {
   );
   await appServer.stop();
 
-  // Copy the files for the template used
+  // Copy files for the template used.
+
+  // Skip thebe JS chunks unless they are required.
   const templateBuildDir = path.join(template.templatePath, 'public');
-  fs.copySync(templateBuildDir, htmlDir);
+  const hasThebe = siteUsesThebe(session);
+  fs.copySync(templateBuildDir, htmlDir, {
+    filter: (src) =>
+      hasThebe ||
+      !path.basename(src).match(/^(\d+\.)?(thebe-(core|lite)(\.min)?\.js|thebe-core.*\.css)$/),
+  });
 
   // Copy all of the static assets
   fs.copySync(session.publicPath(), path.join(htmlDir, 'build'));
+
+  // Copy user static files to html build root
+  const siteConfig = selectors.selectCurrentSiteConfig(session.store.getState());
+  for (const proj of siteConfig?.projects ?? []) {
+    if (!proj.path) continue;
+    const projectConfig = selectors.selectLocalProjectConfig(session.store.getState(), proj.path);
+    copyStaticFiles(session, projectConfig?.static_files ?? [], htmlDir, proj.path);
+  }
   fs.copySync(path.join(session.sitePath(), 'config.json'), path.join(htmlDir, 'config.json'));
   fs.copySync(path.join(session.sitePath(), 'objects.inv'), path.join(htmlDir, 'objects.inv'));
 

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -149,7 +149,7 @@ export async function localToManifestProject(
   const parts = resolveFrontmatterParts(session, projFrontmatter);
   const banner = await transformBanner(
     session,
-    path.join(projectPath, 'myst.yml'),
+    projConfigFile ?? path.join(projectPath, 'myst.yml'),
     projFrontmatter,
     session.publicPath(),
     { altOutputFolder: '/', webp: true },
@@ -157,7 +157,7 @@ export async function localToManifestProject(
   const thumbnail = await transformThumbnail(
     session,
     null,
-    path.join(projectPath, 'myst.yml'),
+    projConfigFile ?? path.join(projectPath, 'myst.yml'),
     projFrontmatter,
     session.publicPath(),
     { altOutputFolder: '/', webp: true },

--- a/packages/myst-cli/src/build/site/start.ts
+++ b/packages/myst-cli/src/build/site/start.ts
@@ -1,10 +1,12 @@
 import chalk from 'chalk';
 import cors from 'cors';
 import express from 'express';
+import type { Application } from 'express';
 import getPort, { portNumbers } from 'get-port';
 import { makeExecutable, killProcessTree } from 'myst-cli-utils';
 import type child_process from 'child_process';
 import { nanoid } from 'nanoid';
+import type { Server } from 'node:http';
 import { join } from 'node:path';
 import type WebSocket from 'ws';
 import { WebSocketServer } from 'ws';
@@ -15,6 +17,34 @@ import { createServerLogger } from './logger.js';
 import { buildSite } from './prepare.js';
 import { installSiteTemplate, getSiteTemplate } from './template.js';
 import { watchContent } from './watch.js';
+
+/*
+Find a free port close to the preferred port and bind to it.
+If that port was taken by the time we tried to bind, probe again and retry.
+ */
+async function listenOnPreferredPort(
+  app: Application,
+  host: string,
+  preferredPort?: number,
+): Promise<{ server: Server; port: number }> {
+  const tryListen = (port: number) =>
+    new Promise<Server>((resolve, reject) => {
+      const s = app.listen(port, host, () => resolve(s));
+      s.once('error', (err) => {
+        s.close();
+        reject(err);
+      });
+    });
+
+  const first = preferredPort ?? (await getPort({ port: portNumbers(3100, 3200) }));
+  try {
+    return { server: await tryListen(first), port: first };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw err;
+    const second = await getPort({ port: portNumbers(3100, 3200) });
+    return { server: await tryListen(second), port: second };
+  }
+}
 
 const DEFAULT_HOST = 'localhost';
 const DEFAULT_START_COMMAND = 'npm run start';
@@ -39,7 +69,7 @@ export type StartOptions = ProcessSiteOptions &
  */
 export async function startContentServer(session: ISession, opts?: ServerOptions) {
   const host = opts?.serverHost || DEFAULT_HOST;
-  const port = opts?.serverPort ?? (await getPort({ port: portNumbers(3100, 3200) }));
+  let port = 0;
   const app = express();
   app.use(cors());
   app.get('/', (req, res) => {
@@ -56,9 +86,9 @@ export async function startContentServer(session: ISession, opts?: ServerOptions
   app.use('/objects.inv', express.static(join(session.sitePath(), 'objects.inv')));
   app.use('/myst.xref.json', express.static(join(session.sitePath(), 'myst.xref.json')));
   app.use('/myst.search.json', express.static(join(session.sitePath(), 'myst.search.json')));
-  const server = app.listen(port, host, () => {
-    session.log.debug(`Content server listening on port ${port}`);
-  });
+  const { server, port: boundPort } = await listenOnPreferredPort(app, host, opts?.serverPort);
+  port = boundPort;
+  session.log.debug(`Content server listening on port ${port}`);
   const wss = new WebSocketServer({
     noServer: true,
     path: '/socket',
@@ -135,6 +165,60 @@ export type ServerInfo = {
   stop: () => Promise<void>;
 };
 
+/*
+Start the app server (npm start) on the given port.
+Rejects if the process exits before emitting the ready signal.
+*/
+async function tryStartAppServer(
+  mystTemplate: Awaited<ReturnType<typeof getSiteTemplate>>,
+  session: ISession,
+  host: string,
+  contentServer: Awaited<ReturnType<typeof startContentServer>>,
+  opts: StartOptions,
+  port: number,
+): Promise<ServerInfo> {
+  const appServer = { port, contentServer } as ServerInfo;
+  let started = false;
+  await new Promise<void>((resolve, reject) => {
+    const start = makeExecutable(
+      mystTemplate.getValidatedTemplateYml().build?.start ?? DEFAULT_START_COMMAND,
+      createServerLogger(session, {
+        host,
+        ready: () => {
+          started = true;
+          resolve();
+        },
+      }),
+      {
+        cwd: mystTemplate.templatePath,
+        env: {
+          ...process.env,
+          HOST: host,
+          CONTENT_CDN_PORT: String(contentServer.port),
+          PORT: String(port),
+          MODE: opts.buildStatic ? 'static' : 'app',
+          BASE_URL: opts.baseurl || undefined,
+        },
+        getProcess(proc) {
+          appServer.process = proc;
+          proc.on('exit', (code) => {
+            if (!started)
+              reject(new Error(`App server exited (code ${code}) before becoming ready`));
+          });
+        },
+      },
+    );
+    start().catch((e) => {
+      if (!started) reject(e);
+    });
+  });
+  appServer.stop = async () => {
+    if (appServer.process) await killProcessTree(appServer.process);
+    contentServer.stop();
+  };
+  return appServer satisfies ServerInfo;
+}
+
 export async function startServer(
   session: ISession,
   opts: StartOptions,
@@ -166,35 +250,11 @@ export async function startServer(
   session.log.info(
     `\n\n\t✨✨✨  Starting ${mystTemplate.getValidatedTemplateYml().title}  ✨✨✨\n\n`,
   );
-  const port = opts?.port ?? (await getPort({ port: portNumbers(3000, 3100) }));
-  const appServer = { port, contentServer } as ServerInfo;
-  await new Promise<void>((resolve) => {
-    const start = makeExecutable(
-      mystTemplate.getValidatedTemplateYml().build?.start ?? DEFAULT_START_COMMAND,
-      createServerLogger(session, { host, ready: resolve }),
-      {
-        cwd: mystTemplate.templatePath,
-        env: {
-          ...process.env,
-          HOST: host,
-          CONTENT_CDN_PORT: String(contentServer.port),
-          PORT: String(port),
-          MODE: opts.buildStatic ? 'static' : 'app',
-          BASE_URL: opts.baseurl || undefined,
-        },
-        getProcess(process) {
-          appServer.process = process;
-        },
-      },
-    );
-    start().catch((e) => session.log.debug(e));
-  });
-  appServer.stop = async () => {
-    if (appServer.process) {
-      await killProcessTree(appServer.process);
-    }
-    contentServer.stop();
-  };
-
-  return appServer satisfies ServerInfo;
+  const first = opts?.port ?? (await getPort({ port: portNumbers(3000, 3100) }));
+  try {
+    return await tryStartAppServer(mystTemplate, session, host, contentServer, opts, first);
+  } catch {
+    const second = await getPort({ port: portNumbers(3000, 3100) });
+    return await tryStartAppServer(mystTemplate, session, host, contentServer, opts, second);
+  }
 }

--- a/packages/myst-cli/src/config-from-path.spec.ts
+++ b/packages/myst-cli/src/config-from-path.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import memfs from 'memfs';
+import { configFromPath } from './config';
+import { Session } from './session';
+
+vi.mock('fs', () => ({ ['default']: memfs.fs }));
+
+beforeEach(() => memfs.vol.reset());
+
+const session = new Session();
+
+describe('configFromPath', () => {
+  it('finds myst.yml', () => {
+    memfs.vol.fromJSON({ '/proj/myst.yml': 'version: 1' });
+    expect(configFromPath(session, '/proj')).toBe('/proj/myst.yml');
+  });
+  it('finds myst.yaml', () => {
+    memfs.vol.fromJSON({ '/proj/myst.yaml': 'version: 1' });
+    expect(configFromPath(session, '/proj')).toBe('/proj/myst.yaml');
+  });
+  it('returns undefined when no config exists', () => {
+    memfs.vol.fromJSON({ '/proj/readme.md': '' });
+    expect(configFromPath(session, '/proj')).toBeUndefined();
+  });
+  it('throws when both myst.yml and myst.yaml exist', () => {
+    memfs.vol.fromJSON({ '/proj/myst.yml': 'version: 1', '/proj/myst.yaml': 'version: 1' });
+    expect(() => configFromPath(session, '/proj')).toThrow('Multiple config files');
+  });
+});

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -1,5 +1,6 @@
 import yaml from 'js-yaml';
 import { basename, extname, join } from 'node:path';
+import fs from 'fs-extra';
 import chalk from 'chalk';
 import { Inventory, Domains } from 'intersphinx';
 import { writeFileToFolder, tic, hashAndCopyStaticFile } from 'myst-cli-utils';
@@ -38,6 +39,7 @@ import { addWarningForFile } from '../utils/addWarningForFile.js';
 import { logMessagesFromVFile } from '../utils/logging.js';
 import { ImageExtensions } from '../utils/resolveExtension.js';
 import { resolveFrontmatterParts } from '../utils/resolveFrontmatterParts.js';
+import { copyStaticFiles } from '../utils/copyStaticFiles.js';
 import version from '../version.js';
 import { combineProjectCitationRenderers } from './citations.js';
 import { loadFile, selectFile } from './file.js';
@@ -627,6 +629,13 @@ export async function processProject(
         }
       }),
     );
+    // Write all static files
+    const projectConfig = selectors.selectLocalProjectConfig(
+      session.store.getState(),
+      siteProject.path,
+    );
+    const staticFiles = projectConfig?.static_files ?? [];
+    copyStaticFiles(session, staticFiles, session.publicPath(), siteProject.path);
     await Promise.all(
       pages.map(async (page) => {
         return writeFile(session, {

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -1,5 +1,6 @@
 import yaml from 'js-yaml';
 import { basename, extname, join } from 'node:path';
+import fs from 'fs-extra';
 import chalk from 'chalk';
 import { Inventory, Domains } from 'intersphinx';
 import { writeFileToFolder, tic, hashAndCopyStaticFile } from 'myst-cli-utils';
@@ -39,6 +40,7 @@ import { addWarningForFile } from '../utils/addWarningForFile.js';
 import { logMessagesFromVFile } from '../utils/logging.js';
 import { ImageExtensions } from '../utils/resolveExtension.js';
 import { resolveFrontmatterParts } from '../utils/resolveFrontmatterParts.js';
+import { copyStaticFiles } from '../utils/copyStaticFiles.js';
 import version from '../version.js';
 import { combineProjectCitationRenderers } from './citations.js';
 import { loadFile, selectFile } from './file.js';
@@ -674,6 +676,13 @@ export async function processProject(
         }
       }),
     );
+    // Write all static files
+    const projectConfig = selectors.selectLocalProjectConfig(
+      session.store.getState(),
+      siteProject.path,
+    );
+    const staticFiles = projectConfig?.static_files ?? [];
+    copyStaticFiles(session, staticFiles, session.publicPath(), siteProject.path);
     await Promise.all(
       pages.map(async (page) => {
         return writeFile(session, {

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -40,7 +40,7 @@ if (!globalThis.fetch) {
   globalThis.Response = Response as any;
 }
 
-const CONFIG_FILES = ['myst.yml'];
+const CONFIG_FILES = ['myst.yml', 'myst.yaml'];
 const DEFAULT_API_URL = 'https://api.mystmd.org';
 const NPM_COMMAND = 'npm i -g mystmd@latest';
 const PIP_COMMAND = 'pip install -U mystmd';

--- a/packages/myst-cli/src/utils/copyStaticFiles.ts
+++ b/packages/myst-cli/src/utils/copyStaticFiles.ts
@@ -1,0 +1,21 @@
+import { basename, join, resolve } from 'node:path';
+import fs from 'fs-extra';
+import type { ISession } from '../session/types.js';
+
+export function copyStaticFiles(
+  session: ISession,
+  staticFiles: string[],
+  destDir: string,
+  projectPath: string,
+) {
+  for (const fn of staticFiles) {
+    const resolvedFn = resolve(projectPath, fn);
+    if (!fs.existsSync(resolvedFn)) {
+      session.log.warn(
+        `Static file not found: "${fn}" (paths are resolved relative to the project root: ${projectPath})`,
+      );
+      continue;
+    }
+    fs.copySync(resolvedFn, join(destDir, basename(resolvedFn)));
+  }
+}

--- a/packages/myst-cli/src/utils/index.ts
+++ b/packages/myst-cli/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './addWarningForFile.js';
+export * from './copyStaticFiles.js';
 export * from './check.js';
 export * from './createTempFolder.js';
 export * from './defined.js';

--- a/packages/myst-config/src/site/types.ts
+++ b/packages/myst-config/src/site/types.ts
@@ -25,6 +25,11 @@ export interface SiteAction {
 }
 
 export type SiteConfig = SiteFrontmatter & {
+  /**
+   * Multiple projects per site is deprecated; a site maps 1:1 to a project.
+   * See https://github.com/jupyter-book/mystmd/issues/1103
+   * TODO: Clean up the `projects` API to clarify that it's only one allowed.
+   */
   projects?: SiteProject[];
   nav?: SiteNavItem[];
   actions?: SiteAction[];
@@ -76,6 +81,11 @@ export type SiteManifest = Omit<SiteFrontmatter, 'parts'> & {
   version: number;
   myst: string;
   id?: string;
+  /**
+   * Multiple projects per site is deprecated; a site maps 1:1 to a project.
+   * See https://github.com/jupyter-book/mystmd/issues/1103
+   * TODO: Clean up the `projects` API to clarify that it's only one allowed.
+   */
   projects?: ManifestProject[];
   nav?: SiteNavItem[];
   actions?: SiteAction[];

--- a/packages/myst-execute/package.json
+++ b/packages/myst-execute/package.json
@@ -35,6 +35,7 @@
     "@jupyterlab/services": "^7.3.0",
     "@jupyterlab/nbformat": "^3.5.2",
     "chalk": "^5.2.0",
+    "get-port": "^6.1.2",
     "myst-cli-utils": "^2.0.13",
     "myst-common": "^1.9.3",
     "node-fetch": "^3.3.0",

--- a/packages/myst-execute/src/kernel.ts
+++ b/packages/myst-execute/src/kernel.ts
@@ -2,20 +2,30 @@ import type { KernelSpec } from 'myst-frontmatter';
 import type { Kernel, KernelMessage, SessionManager } from '@jupyterlab/services';
 import type { IOutput } from '@jupyterlab/nbformat';
 import type { IExpressionResult } from 'myst-common';
+import type { Logger } from 'myst-cli-utils';
 import type { VFile } from 'vfile';
 import path from 'node:path';
 import assert from 'node:assert';
+import { setTimeout as delay } from 'node:timers/promises';
 
 type ISessionConnection = Awaited<ReturnType<SessionManager['startNew']>>;
 type ISessionConnectionWithKernel = ISessionConnection & {
   kernel: NonNullable<ISessionConnection['kernel']>;
 };
 
+// A kernel can start but never finish connecting, which would hang the build
+// forever. Wait for it to be ready, and restart it a few times if it isn't.
+// Healthy kernels connect in about a second, so this timeout is intentionally
+// short to recover quickly.
+const KERNEL_READY_TIMEOUT_MS = 10_000;
+const KERNEL_READY_ATTEMPTS = 3;
+
 export async function createKernelConnection(
   sessionManager: SessionManager,
   basePath: string,
   kernelspec: KernelSpec,
   vfile: VFile,
+  log?: Logger,
 ): Promise<ISessionConnectionWithKernel | undefined> {
   const sessionOpts = {
     type: 'notebook',
@@ -25,11 +35,25 @@ export async function createKernelConnection(
       name: kernelspec.name,
     },
   };
-  const connection = await sessionManager.startNew(sessionOpts);
-  if (connection.kernel === null) {
-    return undefined;
+  for (let attempt = 1; attempt <= KERNEL_READY_ATTEMPTS; attempt += 1) {
+    const connection = await sessionManager.startNew(sessionOpts);
+    if (connection.kernel === null) {
+      return undefined;
+    }
+    const ready = await Promise.race([
+      connection.kernel.info.then(() => true),
+      // ref: false makes sure the timer doesn't keep the process alive if kernel starts
+      delay(KERNEL_READY_TIMEOUT_MS, false, { ref: false }),
+    ]);
+    if (ready) {
+      return connection as any;
+    }
+    log?.warn(
+      `Kernel "${kernelspec.name}" did not become ready (attempt ${attempt}/${KERNEL_READY_ATTEMPTS}); restarting it`,
+    );
+    await connection.shutdown().catch(() => undefined);
   }
-  return connection as any;
+  return undefined;
 }
 
 /**

--- a/packages/myst-execute/src/manager.ts
+++ b/packages/myst-execute/src/manager.ts
@@ -1,5 +1,6 @@
 import type { ServerConnection } from '@jupyterlab/services';
 import which from 'which';
+import getPort from 'get-port';
 import { spawn } from 'node:child_process';
 import * as readline from 'node:readline';
 import type { ISession, Logger } from 'myst-cli-utils';
@@ -77,7 +78,19 @@ export async function launchJupyterServer(
 ): Promise<JupyterServerSettings> {
   log.info(`🚀 ${chalk.yellowBright('Starting new Jupyter server')}`);
   const pythonPath = which.sync('python');
-  const proc = spawn(pythonPath, ['-m', 'jupyter_server', '--ServerApp.root_dir', contentPath]);
+  // Pick an unused port so parallel execution requests don't race on the default port.
+  const port = await getPort();
+  const proc = spawn(pythonPath, [
+    '-m',
+    'jupyter_server',
+    '--ServerApp.root_dir',
+    contentPath,
+    `--ServerApp.port=${port}`,
+    // Without this, jupyter silently rebinds to a different port if ours is taken.
+    // We later parse the port from stderr but it returns the *first* instance,
+    // so if the port has changed after a retry, we'll miss it. So fail eagerly instead.
+    '--ServerApp.port_retries=0',
+  ]);
 
   const reader = proc.stderr;
 

--- a/packages/myst-execute/src/transform.ts
+++ b/packages/myst-execute/src/transform.ts
@@ -144,6 +144,7 @@ export async function kernelExecutionTransform(tree: GenericParent, vfile: VFile
     opts.basePath,
     kernelspec,
     vfile,
+    log,
   );
   if (sessionConnection === undefined) {
     log.error(`Unable to create a new kernel ${kernelspec.name}`);

--- a/packages/myst-execute/tests/run.spec.ts
+++ b/packages/myst-execute/tests/run.spec.ts
@@ -37,7 +37,9 @@ if (pythonPath === null) {
   throw new Error('python not found in PATH; install it to run myst-execute tests');
 }
 if (spawnSync(pythonPath, ['-c', 'import jupyter_server']).status !== 0) {
-  throw new Error('jupyter_server not found; run `pip install jupyter-server` to run myst-execute tests');
+  throw new Error(
+    'jupyter_server not found; run `pip install jupyter-server` to run myst-execute tests',
+  );
 }
 
 const only = '';

--- a/packages/myst-frontmatter/src/project/types.ts
+++ b/packages/myst-frontmatter/src/project/types.ts
@@ -48,6 +48,7 @@ export const PROJECT_FRONTMATTER_KEYS = [
   'references',
   'requirements',
   'resources',
+  'static_files',
   'thebe',
   'toc',
 ];
@@ -87,6 +88,7 @@ export type ProjectFrontmatter = ProjectAndPageFrontmatter & {
   references?: ExternalReferences;
   requirements?: string[];
   resources?: string[];
+  static_files?: string[];
   social?: SocialLinks;
   thebe?: ExpandedThebeFrontmatter;
   toc?: any[];

--- a/packages/myst-frontmatter/src/project/validators.ts
+++ b/packages/myst-frontmatter/src/project/validators.ts
@@ -300,6 +300,15 @@ export function validateProjectFrontmatterKeys(
       },
     );
   }
+  if (defined(value.static_files)) {
+    output.static_files = validateList(
+      value.static_files,
+      incrementOptions('static_files', opts),
+      (file, index) => {
+        return validateString(file, incrementOptions(`static_files.${index}`, opts));
+      },
+    );
+  }
   return output;
 }
 

--- a/packages/myst-to-typst/package.json
+++ b/packages/myst-to-typst/package.json
@@ -40,7 +40,7 @@
     "myst-common": "^1.9.4",
     "myst-frontmatter": "^1.9.4",
     "myst-spec-ext": "^1.9.4",
-    "tex-to-typst": "^0.0.18",
+    "tex-to-typst": "^0.0.20",
     "unist-util-select": "^4.0.3",
     "vfile-reporter": "^7.0.4"
   }

--- a/packages/myst-to-typst/src/index.ts
+++ b/packages/myst-to-typst/src/index.ts
@@ -460,13 +460,24 @@ const handlers: Record<string, Handler> = {
     state.write(')\n\n');
   },
   card(node, state) {
+    state.useMacro('#let card(content) = [#content]');
+    if (!(state.data.isInFigure || state.data.isInTable || state.data.isInBlockquote)) {
+      //FIXME: this is very inelegant. How to avoid # when within a function call?
+      state.write('#');
+    }
+
+    state.write('card([\n');
     if (node.url) {
       node.children?.push({ type: 'paragraph', children: [{ type: 'text', value: node.url }] });
     }
     state.renderChildren(node);
+
+    state.write('])');
+
     state.ensureNewLine();
     state.write('\n');
   },
+
   cardTitle(node, state) {
     state.write('*');
     state.renderChildren(node);

--- a/packages/myst-transforms/src/containers.ts
+++ b/packages/myst-transforms/src/containers.ts
@@ -23,6 +23,7 @@ const SUBFIGURE_TYPES = [
   'table',
   'code',
   'output',
+  'card',
   'anywidget',
 ];
 
@@ -198,7 +199,7 @@ export function containerChildrenTransform(tree: GenericParent, vfile: VFile) {
         {
           node: container,
           ruleId: RuleId.containerChildrenValid,
-          note: 'Valid content types include image, referenced notebook cell, table, code, iframe, subfigure, anywidget',
+          note: 'Valid content types include image, referenced notebook cell, table, code, cards, iframe, subfigure, anywidget',
         },
       );
     }

--- a/packages/mystmd/tests/exports.yml
+++ b/packages/mystmd/tests/exports.yml
@@ -555,6 +555,18 @@ cases:
         content: outputs/site-index-content.json
       - path: site-index/_build/site/content/index-1.json
         content: outputs/site-index-content-1.json
+  - title: Static files - project-level file and folder copied to site build
+    cwd: static-files
+    command: myst build --site
+    outputs:
+      - path: static-files/_build/site/public/project-asset.txt
+      - path: static-files/_build/site/public/assets/nested.txt
+  - title: Static files - project-level file and folder copied to html build
+    cwd: static-files-html
+    command: myst build --html
+    outputs:
+      - path: static-files-html/_build/html/project-asset.txt
+      - path: static-files-html/_build/html/assets/nested.txt
   - title: Hidden pages exist in html build
     cwd: hidden-pages
     command: myst build --html

--- a/packages/mystmd/tests/static-files-html/assets/nested.txt
+++ b/packages/mystmd/tests/static-files-html/assets/nested.txt
@@ -1,0 +1,1 @@
+nested asset

--- a/packages/mystmd/tests/static-files-html/index.md
+++ b/packages/mystmd/tests/static-files-html/index.md
@@ -1,0 +1,5 @@
+---
+title: Static Files HTML Test
+---
+
+# Static Files HTML Test

--- a/packages/mystmd/tests/static-files-html/myst.yml
+++ b/packages/mystmd/tests/static-files-html/myst.yml
@@ -1,0 +1,8 @@
+version: 1
+project:
+  id: b2c3d4e5-f6a7-8901-bcde-f12345678901
+  static_files:
+    - project-asset.txt
+    - assets/
+site:
+  template: book-theme

--- a/packages/mystmd/tests/static-files-html/project-asset.txt
+++ b/packages/mystmd/tests/static-files-html/project-asset.txt
@@ -1,0 +1,1 @@
+project asset

--- a/packages/mystmd/tests/static-files/assets/nested.txt
+++ b/packages/mystmd/tests/static-files/assets/nested.txt
@@ -1,0 +1,1 @@
+nested asset

--- a/packages/mystmd/tests/static-files/index.md
+++ b/packages/mystmd/tests/static-files/index.md
@@ -1,0 +1,5 @@
+---
+title: Static Files Test
+---
+
+# Static Files Test

--- a/packages/mystmd/tests/static-files/myst.yml
+++ b/packages/mystmd/tests/static-files/myst.yml
@@ -1,0 +1,8 @@
+version: 1
+project:
+  id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  static_files:
+    - project-asset.txt
+    - assets/
+site:
+  template: ../templates/site/myst/book-theme

--- a/packages/mystmd/tests/static-files/project-asset.txt
+++ b/packages/mystmd/tests/static-files/project-asset.txt
@@ -1,0 +1,1 @@
+project asset


### PR DESCRIPTION
Periodic sync of the QuantEcon fork with `jupyter-book/mystmd:main`.

## ⚠️ Merge with **"Create a merge commit"** — NOT "Squash and merge"

This PR brings in upstream commits via a real merge commit so that ancestry is preserved and the next `git merge upstream/main` stays clean. Squash-merging would flatten the 16 upstream commits and break future syncs. (See `quantecon/README.md` → "Sync `main` with upstream".)

## What's included

16 upstream commits since the last sync (merge-base `0d626b19`), landing under merge commit `28debe0e`:

- Document site options config w page frontmatter (#2873)
- Add option to specify static files for site builds (#2770)
- Add kernel startup timeout and retry + choose open port on execute (#2874)
- 🐛 Citation `@mention` followed by html parsing bug (#2891)
- 📖 Clarify jtex frontmatter template fields (#2879)
- Document deprecated projects config (#2888)
- 🃏 Wrap card in a passthrough typst function (#2640)
- Add extra guidance around changesets and myst-cli bumping (#2862)
- Only copy thebe JS when necessary (#2878)
- 📖 Document JupyterHub PDF export tools (#2880)
- Ignore ./worktrees dir in linting/formatting (#2881)
- Accept myst.yaml as an alternative to myst.yml (#2884)
- Pin new tex-to-typst (#2889)
- fix(myst-cli): append index-redirect script to end of `<head>` (#2851)
- Add additional documentation for LaTeX PDFs (#2806)
- docs: clarify PDF export prerequisites (#2867)

## Notes

- **No version bump** — upstream `main` remains 1.9.1, so `quantecon/VERSION.yml` (`upstream_base: 1.9.1`) is unchanged.
- **Clean merge, no conflicts.** None of the upstream changes overlap the fork's feature code (book numbering, proof scope, book parts, qe-version CLI). The one file touched by both — `myst-transforms/src/containers.ts` (upstream added `'card'` to subfigure types) — is not modified by the fork.
- `bun.lock` regenerated to reconcile the merged `package.json` files.

## Verification

- `bun install` + `npm run build` (mystmd) succeed
- `myst --version` → `v1.9.1 (qe-v7)` (qe-version feature intact)
- `myst-transforms` enumerate suite: 88/88 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)