### PR TITLE
Track PR #50 (fancy-lists) in fork metadata

### DIFF
--- a/quantecon/UPSTREAM-PRS.yml
+++ b/quantecon/UPSTREAM-PRS.yml
@@ -110,12 +110,13 @@ upstream_candidates:
   - id: fancy-lists
     title: Pandoc-style fancy ordered lists
     description: |
-      Parses Pandoc fancy_lists ordered-list markers (a., B), iv., (i))
-      with inferred style/start; `list` nodes carry `style`/`delimiter`
-      (myst-spec-ext) rendered by the HTML/TeX/Typst/JATS exporters.
-      Plain CommonMark lists keep a byte-identical AST (conformance
-      suite unchanged). Vendored markdown-it-fancy-lists (MIT) extended
-      with the (i) TwoParens form.
+      Parses Pandoc fancy_lists ordered-list markers — `a.`, `B)`,
+      `iv.`, `(i)` — with inferred style/start; `list` nodes carry
+      `style`/`delimiter` (myst-spec-ext) rendered by the
+      HTML/TeX/Typst/JATS exporters. Plain CommonMark lists keep a
+      byte-identical AST (conformance suite unchanged). Vendored
+      markdown-it-fancy-lists (MIT) extended with the `(i)` TwoParens
+      form.
     status: pending
     commits:
       - sha: 1fd33e3f

--- a/quantecon/UPSTREAM-PRS.yml
+++ b/quantecon/UPSTREAM-PRS.yml
@@ -106,3 +106,28 @@ upstream_candidates:
       upstream PR). Could alternatively fold into `book-mode-with-section-scope`
       to ship the complete book UX as one upstream PR — decide at upstream
       time based on maintainer preference.
+
+  - id: fancy-lists
+    title: Pandoc-style fancy ordered lists
+    description: |
+      Parses Pandoc fancy_lists ordered-list markers (a., B), iv., (i))
+      with inferred style/start; `list` nodes carry `style`/`delimiter`
+      (myst-spec-ext) rendered by the HTML/TeX/Typst/JATS exporters.
+      Plain CommonMark lists keep a byte-identical AST (conformance
+      suite unchanged). Vendored markdown-it-fancy-lists (MIT) extended
+      with the (i) TwoParens form.
+    status: pending
+    commits:
+      - sha: 1fd33e3f
+        local_pr: 50
+        title: "Fancy ordered lists: alphabetic, roman, and parenthesized markers"
+    depends_on: []
+    upstream:
+      pr: null
+      branch: null
+      merged_sha: null
+    notes: |
+      Independent of book-mode work; can ship upstream any time. The
+      upstream story pairs naturally with a small jupyter-book/myst-theme
+      PR mapping list `style` to the <ol type> attribute (tracked in
+      QuantEcon/mystmd#51) — mention it in the upstream PR description.

--- a/quantecon/VERSION.yml
+++ b/quantecon/VERSION.yml
@@ -84,3 +84,10 @@ merged_features:
     local_pr: 42
     merge_sha: 95494e41
     tag: qe-v7
+
+  - id: 8
+    name: fancy-lists
+    description: Pandoc-style fancy ordered lists — alpha/roman/(i) markers parsed with style+delimiter through HTML/TeX/Typst/JATS exporters
+    local_pr: 50
+    merge_sha: 1fd33e3f
+    tag: null


### PR DESCRIPTION
Post-merge bookkeeping for #50 per `quantecon/README.md`:

- **VERSION.yml** — appends `merged_features` entry 8 (`fancy-lists`, squash `1fd33e3f`, `tag: null` until a `qe-v8` checkpoint is cut)
- **UPSTREAM-PRS.yml** — adds a standalone `fancy-lists` upstream candidate (`status: pending`, no dependencies); notes the pairing with the myst-theme `<ol type>` follow-up (#51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)