### PR TITLE
Citation scanner respects inline code-span boundaries

### DIFF
--- a/.changeset/cite-code-span.md
+++ b/.changeset/cite-code-span.md
@@ -1,0 +1,5 @@
+---
+"markdown-it-myst": patch
+---
+
+Citation detection no longer scans through inline code spans: an `@`-token enclosed in backticks inside a bracket (e.g. ``[wrap it in `@tf.function` for speed]``) is literal code, not a citation key, so the bracket text and code formatting are preserved instead of becoming a broken cite node.

--- a/packages/markdown-it-myst/src/citations.ts
+++ b/packages/markdown-it-myst/src/citations.ts
@@ -83,8 +83,21 @@ export const citationsPlugin: PluginWithOptions = (md) => {
       const charAfter = state.src.codePointAt(end + 1);
       if (end > 0 && charAfter != 0x28 && charAfter != 0x5b) {
         const str = state.src.slice(state.pos + 1, end);
-        const parts = str.split(';').map((x) => x.match(regexes.citation));
+        const rawParts = str.split(';');
+        const parts = rawParts.map((x) => x.match(regexes.citation));
         if (parts.indexOf(null) >= 0) return false;
+        // Code spans bind tighter than citation brackets: an `@` inside
+        // `...` is literal code, not a citation key
+        const codeSpans = codeSpanRanges(str);
+        if (codeSpans.length) {
+          let partOffset = 0;
+          for (let i = 0; i < parts.length; i++) {
+            const x = parts[i] as RegExpMatchArray;
+            const atPos = partOffset + (x[1]?.length ?? 0) + (x[2]?.length ?? 0);
+            if (codeSpans.some(([from, to]) => atPos >= from && atPos < to)) return false;
+            partOffset += rawParts[i].length + 1; // +1 for the splitting semicolon
+          }
+        }
         let curCol = state.pos + 1;
         const cites = (parts as RegExpMatchArray[]).map(
           (x): Citation & { content: string; col: number[] } => {
@@ -129,6 +142,47 @@ export const citationsPlugin: PluginWithOptions = (md) => {
 
 function trimBraces(label: string): string {
   return label.replace(/^\{(.*)\}$/, '$1');
+}
+
+/**
+ * Ranges `[start, end)` of inline code spans within `str`, following
+ * CommonMark backtick-run matching: a span opened by a run of N backticks
+ * closes only at the next run of exactly N backticks; unmatched runs are
+ * literal text, and backslash-escaped backticks do not open a span.
+ */
+function codeSpanRanges(str: string): [number, number][] {
+  const ranges: [number, number][] = [];
+  let pos = 0;
+  while (pos < str.length) {
+    const char = str[pos];
+    if (char === '\\') {
+      pos += 2;
+      continue;
+    }
+    if (char !== '`') {
+      pos += 1;
+      continue;
+    }
+    const open = pos;
+    while (pos < str.length && str[pos] === '`') pos += 1;
+    const runLength = pos - open;
+    // Find a closing run of exactly the same length
+    let scan = pos;
+    while (scan < str.length) {
+      if (str[scan] !== '`') {
+        scan += 1;
+        continue;
+      }
+      const closeStart = scan;
+      while (scan < str.length && str[scan] === '`') scan += 1;
+      if (scan - closeStart === runLength) {
+        ranges.push([open, scan]);
+        pos = scan;
+        break;
+      }
+    }
+  }
+  return ranges;
 }
 
 // Skip parsing when inside link text or label.

--- a/packages/markdown-it-myst/tests/citations.yml
+++ b/packages/markdown-it-myst/tests/citations.yml
@@ -381,3 +381,93 @@ cases:
           - type: text
             content: '.'
       - type: paragraph_close
+  - title: at-token inside a code span is not a citation
+    md: '**[NEW: wrap it in `@tf.function` for speed]**'
+    tokens:
+      - type: paragraph_open
+      - type: inline
+        children:
+          - type: text
+            content: ''
+          - type: strong_open
+          - type: text
+            content: '[NEW: wrap it in '
+          - type: code_inline
+            content: '@tf.function'
+          - type: text
+            content: ' for speed]'
+          - type: strong_close
+          - type: text
+            content: ''
+      - type: paragraph_close
+  - title: citation with a code-span suffix keeps citing
+    md: '[see @smith2021 and `@tf.function`]'
+    tokens:
+      - type: paragraph_open
+      - type: inline
+        children:
+          - type: cite_group_open
+            content: '['
+          - type: cite
+            content: 'see @smith2021 and `@tf.function`'
+            col: [1, 34]
+            meta:
+              label: smith2021
+              kind: parenthetical
+              suffix:
+                - content: 'and `@tf.function`'
+          - type: cite_group_close
+            content: ']'
+      - type: paragraph_close
+  - title: code-span at-token next to a real key degrades to in-text cite
+    md: '[@real; `@code`]'
+    tokens:
+      - type: paragraph_open
+      - type: inline
+        children:
+          - type: text
+            content: '['
+          - type: cite
+            content: '@real'
+            col: [1, 6]
+            meta:
+              label: real
+              kind: narrative
+          - type: text
+            content: '; '
+          - type: code_inline
+            content: '@code'
+          - type: text
+            content: ']'
+      - type: paragraph_close
+  - title: double-backtick code span guards at-token
+    md: 'wrap [`` `@x` `` here] please'
+    tokens:
+      - type: paragraph_open
+      - type: inline
+        children:
+          - type: text
+            content: 'wrap ['
+          - type: code_inline
+            content: '`@x`'
+          - type: text
+            content: ' here] please'
+      - type: paragraph_close
+  - title: escaped backtick does not open a code span
+    md: 'see [prefix \` @smith2021]'
+    tokens:
+      - type: paragraph_open
+      - type: inline
+        children:
+          - type: text
+            content: 'see '
+          - type: cite_group_open
+            content: '['
+          - type: cite
+            content: 'prefix \` @smith2021'
+            meta:
+              label: smith2021
+              kind: parenthetical
+          - type: cite_group_close
+            content: ']'
+      - type: paragraph_close


### PR DESCRIPTION
Fixes #46

## What

The citation auto-detector's bracket branch regex-scans the **raw text** between `[`…`]` for pandoc `@key` tokens. Because the `citation` inline rule intercepts `[` before the tokenizer ever reaches the backticks inside, a fully code-span-enclosed `@`-token like

```markdown
**[NEW: wrap it in `@tf.function` for speed]**
```

became a broken `cite` node (`label: tf.function`, backtick swallowed into the prefix text), destroying the bracket text and code formatting — plus an unresolved-citation warning.

## How

In `markdown-it-myst`'s citation rule, compute the CommonMark inline code-span ranges within the bracket content (backtick-run matching: a span opened by N backticks closes only at the next run of exactly N; escaped backticks don't open spans) and **back off the bracket-citation parse when a matched `@` falls inside one**.

Notes on scope:

- The **in-text `@` branch needs no guard**: the tokenizer never visits positions inside a code span, so `` `@tf.function` `` outside brackets was already safe (confirmed by the issue's control line).
- Backing off degrades gracefully: in `` [@real; `@code`] `` the bracket parse is rejected but `@real` still cites via the in-text rule and the code span survives.
- A *legitimate* citation whose suffix contains a code span (`` [see @smith2021 and `@tf.function`] ``) still cites `smith2021` — the matched `@` is outside any span, and the suffix's `parseInline` tokenizes the code span correctly.

## Relation to upstream

jupyter-book/mystmd#1618 tracks the overzealous-`@` class for the `[@handle](url)` *link* shape (already guarded here by the `charAfter != 0x28` check and the fork's `isLinkContext`/`isUrlContext` guards). This PR addresses the inline-code shape with a code-span-boundary guard rather than the link-label heuristic — a separate, complementary fix and an upstream candidate.

## Testing

- 5 new token-level cases in `packages/markdown-it-myst/tests/citations.yml`: the issue repro, citation-with-code-span-suffix, the degraded `[@real; `@code`]` case, double-backtick spans, and escaped backticks (which must *not* suppress citation).
- Full monorepo build + test (73 turbo tasks) and lint pass.
- The Deep-Learning book's `**\[NEW: …` escaping workaround becomes unnecessary once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)