### PR TITLE
Track PR #53 (cite-code-span) in fork metadata

### DIFF
--- a/quantecon/UPSTREAM-PRS.yml
+++ b/quantecon/UPSTREAM-PRS.yml
@@ -132,3 +132,34 @@ upstream_candidates:
       upstream story pairs naturally with a small jupyter-book/myst-theme
       PR mapping list `style` to the <ol type> attribute (tracked in
       QuantEcon/mystmd#51) — mention it in the upstream PR description.
+
+  - id: cite-code-span
+    title: Citation scanner respects inline code-span boundaries
+    description: |
+      The citation rule's bracket branch regex-scans raw bracket text,
+      so a backticked `@`-token (e.g. [wrap it in `@tf.function`])
+      became a broken cite node that swallowed the code formatting.
+      Adds CommonMark code-span range detection within the bracket and
+      backs off when a matched `@` falls inside one.
+    status: pending
+    commits:
+      - sha: 00740bc5
+        local_pr: 53
+        title: "Citation scanner respects inline code-span boundaries"
+    depends_on: []
+    upstream:
+      pr: null
+      branch: null
+      merged_sha: null
+    notes: |
+      Upstream context documented in QuantEcon/mystmd#54. Key pitch for
+      the upstream PR: the escaping direction floated in
+      jupyter-book/mystmd#1618 cannot cover this shape — CommonMark
+      makes backslashes literal inside code spans, so a backticked `@`
+      is un-escapable; code spans also bind tighter than brackets in
+      CommonMark's own precedence. Complementary to (not competing
+      with) #1618, which is the [@handle](url) link shape. Precedent:
+      upstream merged the same kind of context-narrowing in
+      jupyter-book/mystmd#2684 (URLs, their #2538) and #2891
+      (@mention + HTML). The code-span shape is unreported upstream
+      as of 2026-06-12.

--- a/quantecon/UPSTREAM-PRS.yml
+++ b/quantecon/UPSTREAM-PRS.yml
@@ -156,7 +156,7 @@ upstream_candidates:
       the upstream PR: the escaping direction floated in
       jupyter-book/mystmd#1618 cannot cover this shape — CommonMark
       makes backslashes literal inside code spans, so a backticked `@`
-      is un-escapable; code spans also bind tighter than brackets in
+      cannot be escaped; code spans also bind tighter than brackets in
       CommonMark's own precedence. Complementary to (not competing
       with) #1618, which is the [@handle](url) link shape. Precedent:
       upstream merged the same kind of context-narrowing in

--- a/quantecon/VERSION.yml
+++ b/quantecon/VERSION.yml
@@ -91,3 +91,10 @@ merged_features:
     local_pr: 50
     merge_sha: 1fd33e3f
     tag: null
+
+  - id: 9
+    name: cite-code-span
+    description: Citation scanner respects inline code-span boundaries — backticked @-tokens in brackets are code, not cite keys
+    local_pr: 53
+    merge_sha: 00740bc5
+    tag: null


### PR DESCRIPTION
Post-merge bookkeeping for #53 per `quantecon/README.md`:

- **VERSION.yml** — appends `merged_features` entry 9 (`cite-code-span`, squash `00740bc5`, `tag: null`)
- **UPSTREAM-PRS.yml** — adds a standalone `cite-code-span` upstream candidate (`status: pending`), with notes distilled from the upstream research in #54 so the eventual upstream PR description is ready-made

🤖 Generated with [Claude Code](https://claude.com/claude-code)