### PR TITLE
prf:proof defaults to enumerated: false (amsthm convention)

### DIFF
--- a/.changeset/proof-unnumbered.md
+++ b/.changeset/proof-unnumbered.md
@@ -1,0 +1,5 @@
+---
+"myst-ext-proof": patch
+---
+
+The bare `proof` / `prf:proof` directive now defaults to `enumerated: false`, matching the LaTeX amsthm `\begin{proof}` convention — a proof is pinned to the theorem it proves and does not get its own number. Theorem-like kinds (`prf:theorem`, `prf:lemma`, …) are unchanged, and `:enumerated: true` opts a proof back in.

--- a/docs/proofs-and-theorems.md
+++ b/docs/proofs-and-theorems.md
@@ -5,7 +5,7 @@ description: MyST supports creating and referencing algorithms, axioms, conjectu
 thumbnail: ./thumbnails/proof.png
 ---
 
-All proof directives can be included using the `prf:kind` pattern, where the proof directives are shown in [](#proof-list). The directive is enumerated by default and can take in an optional title argument which is shown in brackets after the proof.
+All proof directives can be included using the `prf:kind` pattern, where the proof directives are shown in [](#proof-list). The directive is enumerated by default — except the bare `prf:proof`, which is unnumbered by default to match the LaTeX `amsthm` convention (opt in with `:enumerated: true`) — and can take in an optional title argument which is shown in brackets after the proof.
 
 :::{note} Same as Sphinx Proof 🎉
 :class: dropdown

--- a/docs/proofs-and-theorems.md
+++ b/docs/proofs-and-theorems.md
@@ -5,7 +5,7 @@ description: MyST supports creating and referencing algorithms, axioms, conjectu
 thumbnail: ./thumbnails/proof.png
 ---
 
-All proof directives can be included using the `prf:kind` pattern, where the proof directives are shown in [](#proof-list). The directive is enumerated by default — except the bare `prf:proof`, which is unnumbered by default to match the LaTeX `amsthm` convention (opt in with `:enumerated: true`) — and can take in an optional title argument which is shown in brackets after the proof.
+All proof directives can be included using the `prf:kind` pattern, where the proof directives are shown in [](#proof-list). The directive is enumerated by default — except the bare proof directive (`proof` / `prf:proof`), which is unnumbered by default to match the LaTeX `amsthm` convention (opt in with `:enumerated: true`) — and can take in an optional title argument which is shown in brackets after the proof.
 
 :::{note} Same as Sphinx Proof 🎉
 :class: dropdown

--- a/packages/myst-ext-proof/src/proof.ts
+++ b/packages/myst-ext-proof/src/proof.ts
@@ -51,7 +51,10 @@ export const proofDirective: DirectiveSpec = {
     if (data.options?.nonumber !== undefined) {
       enumerated = !data.options.nonumber as boolean;
     } else {
-      enumerated = (data.options?.enumerated as boolean) ?? true;
+      // amsthm convention: the bare proof environment is unnumbered by
+      // default; theorem-like kinds are numbered. Opt in with `enumerated: true`
+      const isBareProof = data.name === 'proof' || data.name === 'prf:proof';
+      enumerated = (data.options?.enumerated as boolean) ?? !isBareProof;
     }
     const proof = {
       type: 'proof',

--- a/packages/myst-ext-proof/tests/proof.spec.ts
+++ b/packages/myst-ext-proof/tests/proof.spec.ts
@@ -27,7 +27,7 @@ describe('proof directive', () => {
             {
               type: 'proof',
               kind: 'proof',
-              enumerated: true,
+              enumerated: false,
               children: [
                 {
                   type: 'admonitionTitle',
@@ -87,5 +87,33 @@ describe('proof directive', () => {
       directives: [proofDirective],
     });
     expect(output).toEqual(expected);
+  });
+  it.each([
+    ['proof', false],
+    ['prf:proof', false],
+    ['prf:theorem', true],
+    ['prf:lemma', true],
+    ['prf:algorithm', true],
+  ])('%s defaults enumerated: %s', (name, enumerated) => {
+    const output = mystParse('```{' + name + '}\ncontent\n```', {
+      directives: [proofDirective],
+    });
+    const proof = (output as any).children[0].children[0];
+    expect(proof.type).toBe('proof');
+    expect(proof.enumerated).toBe(enumerated);
+  });
+  it('prf:proof can opt back in with enumerated: true', () => {
+    const output = mystParse('```{prf:proof}\n:enumerated: true\ncontent\n```', {
+      directives: [proofDirective],
+    });
+    const proof = (output as any).children[0].children[0];
+    expect(proof.enumerated).toBe(true);
+  });
+  it('nonumber still disables numbering on theorem kinds', () => {
+    const output = mystParse('```{prf:theorem}\n:nonumber: true\ncontent\n```', {
+      directives: [proofDirective],
+    });
+    const proof = (output as any).children[0].children[0];
+    expect(proof.enumerated).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #35

## What

The bare `proof` / `prf:proof` directive now defaults to **`enumerated: false`**, matching the LaTeX `amsthm` convention: `\begin{proof}` is unnumbered because a proof is conceptually pinned to the theorem it proves.

The previous default produced "phantom" numbering — every `:::{prf:proof}` block got an enumerator (e.g. `9.2.1`) present in MyST's JSON and xref metadata but never displayed in rendered HTML, silently consuming a counter slot per proof.

## Scope

- Only the **bare** proof name changes (`proof` and `prf:proof`); all theorem-like kinds (`prf:theorem`, `prf:lemma`, `prf:algorithm`, …) keep `enumerated: true`.
- `:enumerated: true` opts a proof back into numbering; the legacy `:nonumber:` flag behaves exactly as before (it takes precedence either way).
- Docs sentence in `proofs-and-theorems.md` updated to state the exception.

## Testing

- New parametrized tests pin the default per kind (`proof`/`prf:proof` → false; `prf:theorem`/`prf:lemma`/`prf:algorithm` → true), the `enumerated: true` opt-in, and `nonumber` on theorem kinds; the existing fixture's `enumerated: true` expectation updated to `false`.
- Full monorepo build + test pass (one local rerun needed for the known-flaky Jupyter execution e2e tests — `fetch failed`, unrelated; see #29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)