### PR TITLE
qe-v8 release metadata: track PRs #56/#57, tag features 8-11

### DIFF
--- a/quantecon/UPSTREAM-PRS.yml
+++ b/quantecon/UPSTREAM-PRS.yml
@@ -69,6 +69,9 @@ upstream_candidates:
       - sha: a63d53f1
         local_pr: 40
         title: "feat(book): shared counters across proof:* kinds (#34)"
+      - sha: 73854511
+        local_pr: 56
+        title: "Code numbering: honour scope in book mode and template in captions"
     depends_on: []
     upstream:
       pr: null
@@ -82,7 +85,12 @@ upstream_candidates:
       direct follow-up to #28's section-scope work — it closes the
       residual counter-share gap so interleaved theorem/lemma/proposition
       enumerators match the LaTeX PDF (LaTeX `\newtheorem{lemma}[theorem]`
-      parity). Naturally part of the same upstream story.
+      parity). Naturally part of the same upstream story. #56 extends
+      AUTO_PREFIX_KINDS to the `code` kind and makes caption nouns follow
+      `numbering[kind].template` — the scope half depends on the bundle's
+      machinery so the squash cannot ship standalone, though the
+      caption-template half is generic and could be split out at
+      cherry-pick time if upstream wants it sooner.
 
   - id: book-parts
     title: Book parts dividers
@@ -163,3 +171,27 @@ upstream_candidates:
       jupyter-book/mystmd#2684 (URLs, their #2538) and #2891
       (@mention + HTML). The code-span shape is unreported upstream
       as of 2026-06-12.
+
+  - id: proof-unnumbered
+    title: prf:proof defaults to enumerated false (amsthm convention)
+    description: |
+      The bare proof / prf:proof directive defaults `enumerated: false`,
+      matching LaTeX amsthm \begin{proof}; theorem-like kinds keep
+      `enumerated: true` and `enumerated: true` opts a proof back in.
+      Removes phantom enumerators that consumed counter slots without
+      ever rendering.
+    status: pending
+    commits:
+      - sha: 75e07a9a
+        local_pr: 57
+        title: "prf:proof defaults to enumerated: false (amsthm convention)"
+    depends_on: []
+    upstream:
+      pr: null
+      branch: null
+      merged_sha: null
+    notes: |
+      Self-contained; myst-ext-proof was byte-identical to upstream/main
+      before this commit, so the cherry-pick is clean. Mild behavior
+      change for any upstream user who relied on numbered bare proofs —
+      call out the `enumerated: true` opt-in in the upstream PR.

--- a/quantecon/VERSION.yml
+++ b/quantecon/VERSION.yml
@@ -32,7 +32,7 @@
 # Doing it in this order means anyone who `cat`s VERSION.yml at tag
 # `qe-v<N+1>` sees a self-consistent file (qe_version matches the tag).
 
-qe_version: qe-v7
+qe_version: qe-v8
 upstream_base: 1.9.1
 
 merged_features:
@@ -90,11 +90,25 @@ merged_features:
     description: Pandoc-style fancy ordered lists — alpha/roman/(i) markers parsed with style+delimiter through HTML/TeX/Typst/JATS exporters
     local_pr: 50
     merge_sha: 1fd33e3f
-    tag: null
+    tag: qe-v8
 
   - id: 9
     name: cite-code-span
     description: Citation scanner respects inline code-span boundaries — backticked @-tokens in brackets are code, not cite keys
     local_pr: 53
     merge_sha: 00740bc5
-    tag: null
+    tag: qe-v8
+
+  - id: 10
+    name: code-numbering
+    description: numbering.code honours scope/book prefix (Listing 1.1) and captions follow the configured template (Listing, not Program)
+    local_pr: 56
+    merge_sha: 73854511
+    tag: qe-v8
+
+  - id: 11
+    name: proof-unnumbered
+    description: Bare proof/prf:proof defaults enumerated false (amsthm convention); theorem kinds unchanged
+    local_pr: 57
+    merge_sha: 75e07a9a
+    tag: qe-v8


### PR DESCRIPTION
Batch release bookkeeping per `quantecon/README.md` (metadata first, then tag, so the tagged tree is self-consistent):

## VERSION.yml
- `qe_version` → **qe-v8**
- New `merged_features`: **10** `code-numbering` (#56, `73854511`) and **11** `proof-unnumbered` (#57, `75e07a9a`)
- `tag: qe-v8` set on features **8–11**: fancy-lists, cite-code-span, code-numbering, proof-unnumbered

## UPSTREAM-PRS.yml
- `73854511` appended to the **book-mode-with-section-scope** bundle — the scope fix builds on the bundle's `AUTO_PREFIX_KINDS` machinery so it can't cherry-pick standalone (note records that the caption-template half is generic and could split out at cherry-pick time)
- New standalone **proof-unnumbered** candidate — `myst-ext-proof` was byte-identical to upstream before the change, clean cherry-pick

## After squash-merging

```bash
git fetch origin && git tag qe-v8 origin/main -m "qe-v8: fancy lists, cite code-span guard, code numbering, unnumbered proofs" && git push origin qe-v8
```

This is the tag book-dp1 / the Deep-Learning book pin to pick up all four fixes (and drop the `\[NEW:` escaping workaround).

🤖 Generated with [Claude Code](https://claude.com/claude-code)