### PR TITLE
Track PR #62 (ci-deflake) in fork metadata

### DIFF
--- a/quantecon/UPSTREAM-PRS.yml
+++ b/quantecon/UPSTREAM-PRS.yml
@@ -195,3 +195,26 @@ upstream_candidates:
       before this commit, so the cherry-pick is clean. Mild behavior
       change for any upstream user who relied on numbered bare proofs —
       call out the `enumerated: true` opt-in in the upstream PR.
+
+  - id: ci-deflake
+    title: Deflake DOI resolver and Jupyter execution tests
+    description: |
+      DOI resolver tests run against recorded doi.org content-negotiation
+      fixtures via a fetch-overridden Session (TEST_LIVE_DOI=1 re-enables
+      the live variants); the e2e export runner supports per-case vitest
+      retry, applied only to the two Jupyter kernel-timing cases.
+    status: pending
+    commits:
+      - sha: e2bac528
+        local_pr: 62
+        title: "Deflake CI: record DOI fixtures, retry Jupyter execution e2e tests"
+    depends_on: []
+    upstream:
+      pr: null
+      branch: null
+      merged_sha: null
+    notes: |
+      Strong upstream candidate: the flaky tests are upstream's own
+      (their #2823 already patched live-DOI data drift once), and the
+      touched files were byte-identical to upstream/main before this
+      commit, so the cherry-pick is clean. Self-contained.

--- a/quantecon/VERSION.yml
+++ b/quantecon/VERSION.yml
@@ -112,3 +112,10 @@ merged_features:
     local_pr: 57
     merge_sha: 75e07a9a
     tag: qe-v8
+
+  - id: 12
+    name: ci-deflake
+    description: DOI resolver tests use recorded doi.org fixtures (TEST_LIVE_DOI=1 for live); Jupyter execution e2e tests get targeted vitest retry
+    local_pr: 62
+    merge_sha: e2bac528
+    tag: null


### PR DESCRIPTION
Post-merge bookkeeping for #62 per `quantecon/README.md`:

- **VERSION.yml** — `merged_features` entry 12 (`ci-deflake`, squash `e2bac528`, `tag: null` — post-qe-v8, picks up whichever tag is cut next)
- **UPSTREAM-PRS.yml** — standalone `ci-deflake` candidate; the flaky tests are upstream's own (their #2823 already patched live-DOI drift once) and the touched files were byte-identical to upstream before the change, so the cherry-pick is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)