### PR TITLE
Track PR #64 (ipynb-attachment-fixes) in fork metadata

### DIFF
--- a/quantecon/UPSTREAM-PRS.yml
+++ b/quantecon/UPSTREAM-PRS.yml
@@ -34,13 +34,19 @@ upstream_candidates:
       - sha: a045d57d
         local_pr: 16
         title: "feat(ipynb): CommonMark ipynb export + image attachment embedding"
+      - sha: a34ab190
+        local_pr: 64
+        title: "ipynb attachments: preserve image titles, resolve files/ output URLs"
     depends_on: []
     upstream:
       pr: null
       branch: null      # set when the upstream/<topic> branch is pushed
       merged_sha: null
     notes: |
-      Self-contained; can ship upstream any time.
+      Self-contained; can ship upstream any time. #64 is a follow-up
+      fixing the attachment-embedding edge cases from the original
+      review (image titles, files/ output-folder resolution, async
+      reads) — cherry-pick it in the same upstream PR.
 
   - id: book-mode-with-section-scope
     title: Book-style numbering (with LaTeX-style section scope and counter sharing)

--- a/quantecon/VERSION.yml
+++ b/quantecon/VERSION.yml
@@ -119,3 +119,10 @@ merged_features:
     local_pr: 62
     merge_sha: e2bac528
     tag: null
+
+  - id: 13
+    name: ipynb-attachment-fixes
+    description: ipynb attachment embedding — preserve image titles, resolve files/ output-folder URLs, async image reads
+    local_pr: 64
+    merge_sha: a34ab190
+    tag: null


### PR DESCRIPTION
Post-merge bookkeeping for #64 per `quantecon/README.md`:

- **VERSION.yml** — `merged_features` entry 13 (`ipynb-attachment-fixes`, squash `a34ab190`, untagged)
- **UPSTREAM-PRS.yml** — appended to the existing `myst-to-ipynb` candidate (the fixes live in that feature's own code), with a note to cherry-pick both commits in the same upstream PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)